### PR TITLE
feat(testing): agregar colección de Bruno para testing de la API

### DIFF
--- a/tp-final-integrador/bruno-collection/auth/folder.bru
+++ b/tp-final-integrador/bruno-collection/auth/folder.bru
@@ -1,0 +1,3 @@
+meta {
+  name: Auth
+}

--- a/tp-final-integrador/bruno-collection/auth/login.bru
+++ b/tp-final-integrador/bruno-collection/auth/login.bru
@@ -1,0 +1,38 @@
+meta {
+  name: Login
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/auth/login
+  body: json
+  auth: none
+}
+
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "email": "nuevoadmin@correo.com",
+    "password": "password123"
+  }
+}
+
+script:post-response {
+  console.log("Response status:", res.status);
+  
+  // Guardar en colección
+  if (res.body && res.body.success && res.body.data && res.body.data.token) {
+    const token = res.body.data.token;
+    bru.setEnvVar("authToken", token);
+    console.log("Token guardado:", token.substring(0, 20) + "...");
+  }
+}
+
+docs {
+  Inicia sesión y guarda el token en {{authToken}}.
+}

--- a/tp-final-integrador/bruno-collection/bruno.json
+++ b/tp-final-integrador/bruno-collection/bruno.json
@@ -1,0 +1,7 @@
+{
+  "version": "1",
+  "name": "Clínica Médica API",
+  "type": "collection",
+  "activeEnvironment": "Development",
+  "ignore": ["node_modules", ".git"]
+}

--- a/tp-final-integrador/bruno-collection/environments/Development.bru
+++ b/tp-final-integrador/bruno-collection/environments/Development.bru
@@ -1,0 +1,4 @@
+vars {
+  baseUrl: http://localhost:3000/api/v1
+  authToken: 
+}

--- a/tp-final-integrador/bruno-collection/especialidades/create.bru
+++ b/tp-final-integrador/bruno-collection/especialidades/create.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Create Especialidad
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/especialidades
+  body: json
+  auth: none
+}
+
+headers {
+  Accept: application/json
+  Content-Type: application/json
+  Authorization: Bearer {{authToken}}
+}
+
+body:json {
+  {
+    "nombre": "NUEVA ESPECIALIDAD"
+  }
+}
+
+docs {
+  Crea una nueva especialidad.
+  Requiere rol ADMIN.
+}

--- a/tp-final-integrador/bruno-collection/especialidades/delete.bru
+++ b/tp-final-integrador/bruno-collection/especialidades/delete.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Delete Especialidad
+  type: http
+  seq: 5
+}
+
+delete {
+  url: {{baseUrl}}/especialidades/{{especialidadId}}
+  body: none
+  auth: none
+}
+
+headers {
+  Accept: application/json
+  Authorization: Bearer {{authToken}}
+}
+
+docs {
+  Realiza un borrado lógico de una especialidad.
+  Requiere rol ADMIN.
+}

--- a/tp-final-integrador/bruno-collection/especialidades/folder.bru
+++ b/tp-final-integrador/bruno-collection/especialidades/folder.bru
@@ -1,0 +1,3 @@
+meta {
+  name: Especialidades
+}

--- a/tp-final-integrador/bruno-collection/especialidades/get-all.bru
+++ b/tp-final-integrador/bruno-collection/especialidades/get-all.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Get All Especialidades
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/especialidades
+  body: none
+  auth: none
+}
+
+headers {
+  Accept: application/json
+  Authorization: Bearer {{authToken}}
+}
+
+docs {
+  Obtiene todas las especialidades activas.
+  Accesible por roles: ADMIN, PACIENTE.
+}

--- a/tp-final-integrador/bruno-collection/especialidades/get-by-id.bru
+++ b/tp-final-integrador/bruno-collection/especialidades/get-by-id.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Get Especialidad by ID
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/especialidades/{{especialidadId}}
+  body: none
+  auth: none
+}
+
+headers {
+  Accept: application/json
+  Authorization: Bearer {{authToken}}
+}
+
+docs {
+  Obtiene una especialidad por su ID.
+  Requiere rol ADMIN.
+}

--- a/tp-final-integrador/bruno-collection/especialidades/update.bru
+++ b/tp-final-integrador/bruno-collection/especialidades/update.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Update Especialidad
+  type: http
+  seq: 4
+}
+
+put {
+  url: {{baseUrl}}/especialidades/{{especialidadId}}
+  body: json
+  auth: none
+}
+
+headers {
+  Accept: application/json
+  Content-Type: application/json
+  Authorization: Bearer {{authToken}}
+}
+
+body:json {
+  {
+    "nombre": "ESPECIALIDAD ACTUALIZADA"
+  }
+}
+
+docs {
+  Actualiza una especialidad.
+  Requiere rol ADMIN.
+}

--- a/tp-final-integrador/bruno-collection/health/health-check.bru
+++ b/tp-final-integrador/bruno-collection/health/health-check.bru
@@ -1,0 +1,14 @@
+meta {
+  name: Comprobar estado de la API
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/health
+  auth: none
+}
+
+docs {
+  Verifica el estado del sistema y la conexión a la base de datos.
+}

--- a/tp-final-integrador/bruno-collection/medicos/add-obra-social.bru
+++ b/tp-final-integrador/bruno-collection/medicos/add-obra-social.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Asociar Obra Social
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/medicos/:id/obras-sociales
+  body: json
+  auth: inherit
+}
+
+params:path {
+  id: 1
+}
+
+body:json {
+  {
+    "id_obra_social": 4
+  }
+}
+
+docs {
+  Asocia una obra social a un médico.
+}

--- a/tp-final-integrador/bruno-collection/medicos/folder.bru
+++ b/tp-final-integrador/bruno-collection/medicos/folder.bru
@@ -1,0 +1,11 @@
+meta {
+  name: medicos
+}
+
+auth {
+  mode: bearer
+}
+
+auth:bearer {
+  token: {{authToken}}
+}

--- a/tp-final-integrador/bruno-collection/medicos/get-all.bru
+++ b/tp-final-integrador/bruno-collection/medicos/get-all.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Listar Médicos
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/medicos
+  body: none
+  auth: inherit
+}
+
+params:query {
+  ~especialidad: 1
+}
+
+docs {
+  Lista todos los médicos activos. 
+  
+  **Filtros:**
+  - `especialidad` (query): ID de la especialidad.
+}

--- a/tp-final-integrador/bruno-collection/medicos/remove-obra-social.bru
+++ b/tp-final-integrador/bruno-collection/medicos/remove-obra-social.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Desvincular Obra Social
+  type: http
+  seq: 4
+}
+
+delete {
+  url: {{baseUrl}}/medicos/:id/obras-sociales/:id_obra_social
+  body: none
+  auth: inherit
+}
+
+params:path {
+  id: 1
+  id_obra_social: 4
+}
+
+docs {
+  Desvincula una obra social de un médico (soft-delete).
+}

--- a/tp-final-integrador/bruno-collection/medicos/update-especialidad.bru
+++ b/tp-final-integrador/bruno-collection/medicos/update-especialidad.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Actualizar Especialidad
+  type: http
+  seq: 2
+}
+
+put {
+  url: {{baseUrl}}/medicos/:id/especialidad
+  body: json
+  auth: inherit
+}
+
+params:path {
+  id: 1
+}
+
+body:json {
+  {
+    "id_especialidad": 2
+  }
+}
+
+docs {
+  Permite al Administrador actualizar la especialidad de un médico.
+}

--- a/tp-final-integrador/bruno-collection/obras-sociales/create.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/create.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Create Obra Social
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/obras-sociales
+  body: json
+  auth: none
+}
+
+headers {
+  Accept: application/json
+  Content-Type: application/json
+  Authorization: Bearer {{authToken}}
+}
+
+body:json {
+  {
+    "nombre": "Nueva Obra Social",
+    "descripcion": "Descripción de prueba",
+    "porcentajeDescuento": 15.5,
+    "esParticular": false
+  }
+}
+
+docs {
+  Crea una nueva obra social. Requiere rol ADMIN.
+}

--- a/tp-final-integrador/bruno-collection/obras-sociales/folder.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/folder.bru
@@ -1,0 +1,3 @@
+meta {
+  name: Obras Sociales
+}

--- a/tp-final-integrador/bruno-collection/obras-sociales/get-all.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/get-all.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Get All Obras Sociales
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/obras-sociales
+  body: none
+  auth: none
+}
+
+script:pre-request {
+  const token = bru.getEnvVar('authToken');
+  console.log("authToken desde script:", token);
+}
+
+headers {
+  Accept: application/json
+  Authorization: Bearer {{authToken}}
+}
+
+docs {
+  Obtiene todas las obras sociales activas. Requiere rol ADMIN.
+}

--- a/tp-final-integrador/bruno-collection/pacientes/folder.bru
+++ b/tp-final-integrador/bruno-collection/pacientes/folder.bru
@@ -1,0 +1,11 @@
+meta {
+  name: pacientes
+}
+
+auth {
+  mode: bearer
+}
+
+auth:bearer {
+  token: {{authToken}}
+}

--- a/tp-final-integrador/bruno-collection/pacientes/update-obra-social.bru
+++ b/tp-final-integrador/bruno-collection/pacientes/update-obra-social.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Actualizar Obra Social de Paciente
+  type: http
+  seq: 1
+}
+
+put {
+  url: {{baseUrl}}/pacientes/:id/obra-social
+  body: json
+  auth: inherit
+}
+
+params:path {
+  id: 1
+}
+
+body:json {
+  {
+    "id_obra_social": 2
+  }
+}
+
+docs {
+  Permite al Administrador actualizar la obra social de un paciente.
+}

--- a/tp-final-integrador/bruno-collection/usuarios/folder.bru
+++ b/tp-final-integrador/bruno-collection/usuarios/folder.bru
@@ -1,0 +1,3 @@
+meta {
+  name: Usuarios
+}

--- a/tp-final-integrador/bruno-collection/usuarios/register-admin.bru
+++ b/tp-final-integrador/bruno-collection/usuarios/register-admin.bru
@@ -1,0 +1,31 @@
+meta {
+  name: Register Admin
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/usuarios
+  body: json
+  auth: none
+}
+
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "documento": "11222333",
+    "apellido": "Admin",
+    "nombres": "Nuevo",
+    "email": "nuevoadmin@correo.com",
+    "password": "password123",
+    "rol": 3
+  }
+}
+
+docs {
+  Registra un nuevo administrador.
+}

--- a/tp-final-integrador/bruno-collection/usuarios/register-medico.bru
+++ b/tp-final-integrador/bruno-collection/usuarios/register-medico.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Register Medico
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/usuarios
+  body: json
+  auth: none
+}
+
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "documento": "77888999",
+    "apellido": "Sosa",
+    "nombres": "Carlos",
+    "email": "drsosa@correo.com",
+    "password": "password123",
+    "rol": 1,
+    "id_especialidad": 1,
+    "matricula": 98765,
+    "valor_consulta": 8500.00
+  }
+}
+
+docs {
+  Registra un nuevo médico con su especialidad y matrícula.
+}

--- a/tp-final-integrador/bruno-collection/usuarios/register-paciente.bru
+++ b/tp-final-integrador/bruno-collection/usuarios/register-paciente.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Register Paciente
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/usuarios
+  body: json
+  auth: none
+}
+
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "documento": "44555666",
+    "apellido": "Gomez",
+    "nombres": "Ana",
+    "email": "anagomez@correo.com",
+    "password": "password123",
+    "rol": 2,
+    "id_obra_social": 1
+  }
+}
+
+docs {
+  Registra un nuevo paciente asociado a una obra social.
+}

--- a/tp-final-integrador/bruno-collection/usuarios/register-with-photo.bru
+++ b/tp-final-integrador/bruno-collection/usuarios/register-with-photo.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Registrar Paciente con foto
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/usuarios
+  body: multipartForm
+  auth: none
+}
+
+headers {
+  Accept: application/json
+}
+
+body:multipart-form {
+  documento: 44555777
+  apellido: Rodriguez
+  nombres: Carlos
+  email: carlosrodriguez@correo.com
+  password: password123
+  rol: 2
+  id_obra_social: 1
+  foto: @file(/home/horacio/Pictures/Gemini_Generated_Image_9kwkrj9kwkrj9kwk.png)
+}
+
+script:post-response {
+  console.log("Response status:", res.status);
+  console.log("Response body:", JSON.stringify(res.body, null, 2));
+}
+
+docs {
+  Registra un nuevo paciente con foto de perfil.
+}


### PR DESCRIPTION
Agrega una colección de Bruno estructurada para facilitar el testing manual y la documentación de los endpoints de la API.

Esta colección permite al equipo probar la API de forma rápida y consistente.

### Características principales:
- **Persistencia automática del token:** Al hacer login, el script captura el JWT y lo guarda solo en la variable `{{authToken}}`. No más copy-paste manual.
- **Entorno por defecto:** El ambiente "Development" viene preconfigurado y se activa automáticamente al abrir la colección gracias a la configuración en `bruno.json`.
- **Ejemplos multi-rol:** Requests listos para registrar Administradores, Médicos y Pacientes con todas las validaciones necesarias.

### Cómo usar:
1. Instalar [Bruno](https://www.usebruno.com/) (es open source y liviano).
2. "Open Collection" y elegir la carpeta `tp-final-integrador/bruno-collection`.
3. Verificar que el entorno **Development** esté seleccionado (arriba a la derecha).
4. Ejecutar el request de **Login** (en la carpeta `auth`) para autenticarse.
5. ¡Listo! Ya podés usar el resto de los endpoints (ej. `Get All` de Obras Sociales) que usarán el token automáticamente.

<img width="1916" height="701" alt="image" src="https://github.com/user-attachments/assets/b673f8ff-eab5-415b-810e-99a58f3a262f" />

