### PR TITLE
feat: implement strict 405 method not allowed responses

### DIFF
--- a/tp-final-integrador/src/helpers/errors.helper.js
+++ b/tp-final-integrador/src/helpers/errors.helper.js
@@ -26,6 +26,11 @@ export const ERROR_CODES = {
     status: 409,
     message: 'Ya existe un registro con los datos proporcionados',
   },
+  METHOD_NOT_ALLOWED: {
+    code: 'METHOD_NOT_ALLOWED',
+    status: 405,
+    message: 'El método HTTP no está permitido para esta ruta',
+  },
 };
 
 /**

--- a/tp-final-integrador/src/middlewares/method.middleware.js
+++ b/tp-final-integrador/src/middlewares/method.middleware.js
@@ -1,0 +1,15 @@
+import { errorResponse } from '../helpers/response.helper.js';
+import { ERROR_CODES } from '../helpers/errors.helper.js';
+
+/**
+ * Middleware para manejar métodos no permitidos (405)
+ * @param {string[]} allowedMethods - Métodos permitidos para la ruta
+ */
+export const methodNotAllowedHandler = (allowedMethods) => (req, res) => {
+  res.setHeader('Allow', allowedMethods.join(', '));
+  return errorResponse(
+    res,
+    `El método ${req.method} no está permitido para la ruta ${req.originalUrl}`,
+    ERROR_CODES.METHOD_NOT_ALLOWED,
+  );
+};

--- a/tp-final-integrador/src/modules/auth/auth.routes.js
+++ b/tp-final-integrador/src/modules/auth/auth.routes.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import * as authController from './auth.controller.js';
 import { loginValidator } from './auth.validator.js';
+import { methodNotAllowedHandler } from '../../middlewares/method.middleware.js';
 
 const router = Router();
 
@@ -9,6 +10,9 @@ const router = Router();
  */
 
 // POST /api/v1/auth/login
-router.post('/login', loginValidator, authController.login);
+router
+  .route('/login')
+  .post(loginValidator, authController.login)
+  .all(methodNotAllowedHandler(['POST']));
 
 export default router;

--- a/tp-final-integrador/src/modules/health/health.routes.js
+++ b/tp-final-integrador/src/modules/health/health.routes.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import * as healthController from './health.controller.js';
+import { methodNotAllowedHandler } from '../../middlewares/method.middleware.js';
 
 const router = Router();
 
@@ -7,6 +8,9 @@ const router = Router();
  * @route GET /api/v1/health
  * @desc Reporte de salud completo del sistema
  */
-router.get('/', healthController.getHealth);
+router
+  .route('/')
+  .get(healthController.getHealth)
+  .all(methodNotAllowedHandler(['GET']));
 
 export default router;

--- a/tp-final-integrador/src/modules/obras_sociales/obras_sociales.routes.js
+++ b/tp-final-integrador/src/modules/obras_sociales/obras_sociales.routes.js
@@ -4,6 +4,7 @@ import * as obrasSocialesValidator from './obras_sociales.validator.js';
 import { ROLES } from '../../constants/roles.constants.js';
 import { verifyToken, requireRole } from '../../middlewares/auth.middleware.js';
 import { validateRequest } from '../../middlewares/validate.middleware.js';
+import { methodNotAllowedHandler } from '../../middlewares/method.middleware.js';
 
 const obrasSocialesRouter = Router();
 
@@ -16,34 +17,29 @@ const obrasSocialesRouter = Router();
 obrasSocialesRouter.use(verifyToken);
 obrasSocialesRouter.use(requireRole([ROLES.ADMIN]));
 
-obrasSocialesRouter.get('/', obrasSocialesController.getAll);
+obrasSocialesRouter
+  .route('/')
+  .get(obrasSocialesController.getAll)
+  .post(
+    obrasSocialesValidator.validateCreate,
+    validateRequest,
+    obrasSocialesController.createObraSocial,
+  )
+  .all(methodNotAllowedHandler(['GET', 'POST']));
 
-obrasSocialesRouter.get(
-  '/:id',
-  obrasSocialesValidator.validateId,
-  validateRequest,
-  obrasSocialesController.getById,
-);
-
-obrasSocialesRouter.post(
-  '/',
-  obrasSocialesValidator.validateCreate,
-  validateRequest,
-  obrasSocialesController.createObraSocial,
-);
-
-obrasSocialesRouter.put(
-  '/:id',
-  obrasSocialesValidator.validateUpdate,
-  validateRequest,
-  obrasSocialesController.updateObraSocial,
-);
-
-obrasSocialesRouter.delete(
-  '/:id',
-  obrasSocialesValidator.validateId,
-  validateRequest,
-  obrasSocialesController.removeObraSocial,
-);
+obrasSocialesRouter
+  .route('/:id')
+  .get(obrasSocialesValidator.validateId, validateRequest, obrasSocialesController.getById)
+  .put(
+    obrasSocialesValidator.validateUpdate,
+    validateRequest,
+    obrasSocialesController.updateObraSocial,
+  )
+  .delete(
+    obrasSocialesValidator.validateId,
+    validateRequest,
+    obrasSocialesController.removeObraSocial,
+  )
+  .all(methodNotAllowedHandler(['GET', 'PUT', 'DELETE']));
 
 export { obrasSocialesRouter };

--- a/tp-final-integrador/tests/modules/auth.test.js
+++ b/tp-final-integrador/tests/modules/auth.test.js
@@ -42,5 +42,14 @@ describe('Auth Integration Tests', () => {
       expect(response.body.success).toBe(false);
       expect(response.body.error.code).toBe('VALIDATION_ERROR');
     });
+
+    it('debería retornar 405 Method Not Allowed para métodos no soportados', async () => {
+      const response = await request(app).get('/api/v1/auth/login');
+
+      expect(response.status).toBe(405);
+      expect(response.header).toHaveProperty('allow', 'POST');
+      expect(response.body.success).toBe(false);
+      expect(response.body.error.code).toBe('METHOD_NOT_ALLOWED');
+    });
   });
 });

--- a/tp-final-integrador/tests/modules/health.test.js
+++ b/tp-final-integrador/tests/modules/health.test.js
@@ -36,5 +36,14 @@ describe('Health Module Integration Tests', () => {
       expect(response.body.success).toBe(false);
       expect(response.body.error.code).toBe('DATABASE_ERROR');
     });
+
+    it('debería retornar 405 Method Not Allowed para métodos no soportados', async () => {
+      const response = await request(app).post('/api/v1/health');
+
+      expect(response.status).toBe(405);
+      expect(response.header).toHaveProperty('allow', 'GET');
+      expect(response.body.success).toBe(false);
+      expect(response.body.error.code).toBe('METHOD_NOT_ALLOWED');
+    });
   });
 });

--- a/tp-final-integrador/tests/modules/obras_sociales.test.js
+++ b/tp-final-integrador/tests/modules/obras_sociales.test.js
@@ -206,4 +206,26 @@ describe('Obras Sociales - Integration Tests', () => {
       expect(rows[0].activo).toBe(0);
     });
   });
+
+  describe('Métodos No Permitidos (405)', () => {
+    it('debería retornar 405 para métodos no soportados en la colección (/)', async () => {
+      const response = await request(app)
+        .patch('/api/v1/obras-sociales')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(response.status).toBe(405);
+      expect(response.header).toHaveProperty('allow', 'GET, POST');
+      expect(response.body.error.code).toBe('METHOD_NOT_ALLOWED');
+    });
+
+    it('debería retornar 405 para métodos no soportados en el recurso (/:id)', async () => {
+      const response = await request(app)
+        .post('/api/v1/obras-sociales/1')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(response.status).toBe(405);
+      expect(response.header).toHaveProperty('allow', 'GET, PUT, DELETE');
+      expect(response.body.error.code).toBe('METHOD_NOT_ALLOWED');
+    });
+  });
 });


### PR DESCRIPTION
# feat: Implementación estricta de respuestas 405 Method Not Allowed

Este Pull Request implementa el manejo estandarizado del error HTTP **405 Method Not Allowed** en los endpoints principales de la API, reemplazando el comportamiento por defecto de Express (que caía en un 404).

## Cambios Introducidos

### 1. Middleware de Métodos No Permitidos
- Se creó `src/middlewares/method.middleware.js`, un handler especializado que:
  - Establece el encabezado HTTP `Allow` con los métodos permitidos para cada ruta.
  - Retorna una respuesta de error estandarizada con el código `METHOD_NOT_ALLOWED`.

### 2. Refactorización de Rutas (RESTful)
- Se migraron los enrutadores de los módulos **Health**, **Auth** y **Obras Sociales** al patrón `router.route()`.
- Se añadió el manejador de 405 al final de cada definición de ruta mediante `.all()`.

### 3. Códigos de Error
- Se agregó `METHOD_NOT_ALLOWED` (status 405) al diccionario global de errores en `src/helpers/errors.helper.js`.

## Verificación y Tests
- Se añadieron casos de prueba de integración en:
  - `tests/modules/health.test.js`
  - `tests/modules/auth.test.js`
  - `tests/modules/obras_sociales.test.js`
- Se validó tanto el código de estado **405** como la presencia y exactitud del header **Allow**.
- **Resultado final:** 39 tests ejecutados y aprobados (100% success).

## Impacto
Este cambio mejora la calidad de la API al ser más descriptiva con los consumidores sobre qué métodos son válidos para cada recurso, cumpliendo con los estándares de diseño REST.

Relacionado con #55