### PR TITLE
refactor: migrate auth to database SHA2 and rename login field

### DIFF
--- a/prog3_turnos.sql
+++ b/prog3_turnos.sql
@@ -211,7 +211,7 @@ INSERT INTO `usuarios` (`id_usuario`, `documento`, `apellido`, `nombres`, `email
 (6, '41000112', 'Hunk', 'Lorena', 'hunlor@correo.com', '464db19217fabdaabc5add321054f39216d03edfef2efaf8c6769485415b7f25', '', 2, 1),
 (7, '41000113', 'Aguirre', 'Brian', 'agubri@correo.com', '2dfa174ae2688ec55d00f57c5a0a7783ba1f0e2981ab7df9f1cf933686c15274', '', 2, 1),
 (8, '51000111', 'Fernandez', 'Benito', 'ferben@correo.com', 'f127f4e9e4248f77eaa446ea9bff721e3e79eedf114ba6e1cfc633853ef07b4c', '', 3, 1),
-(10, '51000112', 'Gomez', 'Silvia', 'gomsil@correo.com', '601de117008d80e65ffad05dce97462d8f1b1e9aad6d68cf2b289703b8366b52', '', 3, 1);
+(10, '51000112', 'Gomez', 'Silvia', 'gomsil@correo.com', '76a8c23df7d396e6ff724af4263a4f1cb3f9858e1c29c449ac1153b34020bd26', '', 3, 1);
 
 -- --------------------------------------------------------
 

--- a/prog3_turnos_modif.sql
+++ b/prog3_turnos_modif.sql
@@ -211,7 +211,7 @@ INSERT INTO `usuarios` (`id_usuario`, `documento`, `apellido`, `nombres`, `email
 (6, '41000112', 'Hunk', 'Lorena', 'hunlor@correo.com', '464db19217fabdaabc5add321054f39216d03edfef2efaf8c6769485415b7f25', '', 2, 1),
 (7, '41000113', 'Aguirre', 'Brian', 'agubri@correo.com', '2dfa174ae2688ec55d00f57c5a0a7783ba1f0e2981ab7df9f1cf933686c15274', '', 2, 1),
 (8, '51000111', 'Fernandez', 'Benito', 'ferben@correo.com', 'f127f4e9e4248f77eaa446ea9bff721e3e79eedf114ba6e1cfc633853ef07b4c', '', 3, 1),
-(10, '51000112', 'Gomez', 'Silvia', 'gomsil@correo.com', '601de117008d80e65ffad05dce97462d8f1b1e9aad6d68cf2b289703b8366b52', '', 3, 1);
+(10, '51000112', 'Gomez', 'Silvia', 'gomsil@correo.com', '76a8c23df7d396e6ff724af4263a4f1cb3f9858e1c29c449ac1153b34020bd26', '', 3, 1);
 
 -- --------------------------------------------------------
 

--- a/tp-final-integrador/init/schema.sql
+++ b/tp-final-integrador/init/schema.sql
@@ -211,7 +211,7 @@ INSERT INTO `usuarios` (`id_usuario`, `documento`, `apellido`, `nombres`, `email
 (6, '41000112', 'Hunk', 'Lorena', 'hunlor@correo.com', '464db19217fabdaabc5add321054f39216d03edfef2efaf8c6769485415b7f25', '', 2, 1),
 (7, '41000113', 'Aguirre', 'Brian', 'agubri@correo.com', '2dfa174ae2688ec55d00f57c5a0a7783ba1f0e2981ab7df9f1cf933686c15274', '', 2, 1),
 (8, '51000111', 'Fernandez', 'Benito', 'ferben@correo.com', 'f127f4e9e4248f77eaa446ea9bff721e3e79eedf114ba6e1cfc633853ef07b4c', '', 3, 1),
-(10, '51000112', 'Gomez', 'Silvia', 'gomsil@correo.com', '601de117008d80e65ffad05dce97462d8f1b1e9aad6d68cf2b289703b8366b52', '', 3, 1);
+(10, '51000112', 'Gomez', 'Silvia', 'gomsil@correo.com', '76a8c23df7d396e6ff724af4263a4f1cb3f9858e1c29c449ac1153b34020bd26', '', 3, 1);
 
 -- --------------------------------------------------------
 

--- a/tp-final-integrador/package-lock.json
+++ b/tp-final-integrador/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "bcryptjs": "3.0.3",
         "cors": "2.8.6",
         "express": "5.2.1",
         "express-validator": "7.3.2",
@@ -1140,15 +1139,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
-    },
-    "node_modules/bcryptjs": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
-      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
-      "license": "BSD-3-Clause",
-      "bin": {
-        "bcrypt": "bin/bcrypt"
-      }
     },
     "node_modules/body-parser": {
       "version": "2.2.2",

--- a/tp-final-integrador/package.json
+++ b/tp-final-integrador/package.json
@@ -24,7 +24,6 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "bcryptjs": "3.0.3",
     "cors": "2.8.6",
     "express": "5.2.1",
     "express-validator": "7.3.2",

--- a/tp-final-integrador/src/modules/auth/auth.controller.js
+++ b/tp-final-integrador/src/modules/auth/auth.controller.js
@@ -10,8 +10,8 @@ import { successResponse } from '../../helpers/response.helper.js';
  * Maneja el inicio de sesión.
  */
 export const login = async (req, res) => {
-  const { email, password } = matchedData(req);
-  const result = await authService.login(email, password);
+  const { email, contrasenia } = matchedData(req);
+  const result = await authService.login(email, contrasenia);
 
   return successResponse(res, result);
 };

--- a/tp-final-integrador/src/modules/auth/auth.service.js
+++ b/tp-final-integrador/src/modules/auth/auth.service.js
@@ -1,5 +1,4 @@
 import jwt from 'jsonwebtoken';
-import bcryptjs from 'bcryptjs';
 import * as usuariosModel from '../usuarios/usuarios.model.js';
 import { AppError, ERROR_CODES } from '../../helpers/errors.helper.js';
 
@@ -10,19 +9,13 @@ import { AppError, ERROR_CODES } from '../../helpers/errors.helper.js';
 /**
  * Inicia sesión de un usuario.
  * @param {string} email
- * @param {string} password
+ * @param {string} contrasenia
  * @returns {Promise<Object>} Token y datos del usuario.
  */
-export const login = async (email, password) => {
-  const user = await usuariosModel.findByEmail(email);
+export const login = async (email, contrasenia) => {
+  const user = await usuariosModel.findByEmailAndContrasenia(email, contrasenia);
 
   if (!user) {
-    throw new AppError(ERROR_CODES.UNAUTHORIZED, 'Credenciales inválidas');
-  }
-
-  const isPasswordValid = await bcryptjs.compare(password, user.contrasenia);
-
-  if (!isPasswordValid) {
     throw new AppError(ERROR_CODES.UNAUTHORIZED, 'Credenciales inválidas');
   }
 
@@ -36,11 +29,9 @@ export const login = async (email, password) => {
   const token = jwt.sign(payload, process.env.JWT_SECRET || 'secret', {
     expiresIn: process.env.JWT_EXPIRES_IN || '1h',
   });
-  // eslint-disable-next-line no-unused-vars
-  const { contrasenia: _, ...userWithoutPassword } = user;
 
   return {
     token,
-    user: userWithoutPassword,
+    user,
   };
 };

--- a/tp-final-integrador/src/modules/auth/auth.validator.js
+++ b/tp-final-integrador/src/modules/auth/auth.validator.js
@@ -13,6 +13,6 @@ export const loginValidator = [
     .withMessage('Debe ser un email válido')
     .notEmpty()
     .withMessage('El email es requerido'),
-  body('password').notEmpty().withMessage('La contraseña es requerida'),
+  body('contrasenia').notEmpty().withMessage('La contraseña es requerida'),
   validateRequest,
 ];

--- a/tp-final-integrador/src/modules/usuarios/usuarios.model.js
+++ b/tp-final-integrador/src/modules/usuarios/usuarios.model.js
@@ -16,6 +16,22 @@ export const findByEmail = async (email) => {
 };
 
 /**
+ * Busca un usuario por su email y verifica su contraseña usando SHA2 de MySQL.
+ * @param {string} email
+ * @param {string} contrasenia
+ * @returns {Promise<Object|null>}
+ */
+export const findByEmailAndContrasenia = async (email, contrasenia) => {
+  const [rows] = await pool.execute(
+    'SELECT id_usuario, documento, apellido, nombres, email, rol FROM usuarios WHERE email = ? AND contrasenia = SHA2(?, 256) AND activo = 1',
+    [email, contrasenia],
+  );
+
+  if (rows.length === 0) return null;
+  return rows[0];
+};
+
+/**
  * Busca un usuario por su ID.
  * @param {number} id
  * @returns {Promise<Object|null>}

--- a/tp-final-integrador/tests/modules/auth.service.test.js
+++ b/tp-final-integrador/tests/modules/auth.service.test.js
@@ -10,9 +10,9 @@ describe('Auth Service', () => {
 
   it('debe autenticar un usuario con credenciales válidas y devolver un token', async () => {
     const email = 'ferben@correo.com';
-    const password = 'password123'; // Definida en el seed
+    const contrasenia = 'password123'; // Definida en el seed
 
-    const result = await authService.login(email, password);
+    const result = await authService.login(email, contrasenia);
 
     expect(result).toBeDefined();
     expect(result.token).toBeDefined();
@@ -23,9 +23,9 @@ describe('Auth Service', () => {
 
   it('debe fallar si la contraseña es incorrecta', async () => {
     const email = 'ferben@correo.com';
-    const password = 'wrongpassword';
+    const contrasenia = 'wrongpassword';
 
-    await expect(authService.login(email, password)).rejects.toThrow('Credenciales inválidas');
+    await expect(authService.login(email, contrasenia)).rejects.toThrow('Credenciales inválidas');
   });
 
   it('debe fallar si el usuario no existe', async () => {

--- a/tp-final-integrador/tests/modules/auth.test.js
+++ b/tp-final-integrador/tests/modules/auth.test.js
@@ -12,7 +12,7 @@ describe('Auth Integration Tests', () => {
     it('debería iniciar sesión correctamente con credenciales válidas', async () => {
       const response = await request(app).post('/api/v1/auth/login').send({
         email: 'ferben@correo.com',
-        password: 'password123',
+        contrasenia: 'password123',
       });
 
       expect(response.status).toBe(200);
@@ -24,7 +24,7 @@ describe('Auth Integration Tests', () => {
     it('debería fallar con credenciales incorrectas', async () => {
       const response = await request(app).post('/api/v1/auth/login').send({
         email: 'ferben@correo.com',
-        password: 'wrong',
+        contrasenia: 'wrong',
       });
 
       expect(response.status).toBe(401);
@@ -35,7 +35,7 @@ describe('Auth Integration Tests', () => {
     it('debería fallar con datos de entrada inválidos (express-validator)', async () => {
       const response = await request(app).post('/api/v1/auth/login').send({
         email: 'not-an-email',
-        password: '',
+        contrasenia: '',
       });
 
       expect(response.status).toBe(422);

--- a/tp-final-integrador/tests/setup/seed.js
+++ b/tp-final-integrador/tests/setup/seed.js
@@ -1,15 +1,14 @@
-import bcryptjs from 'bcryptjs';
+import crypto from 'node:crypto';
 import { ROLES } from '../../src/constants/roles.constants.js';
 import { pool } from '../../src/config/db.js';
 
 export async function seedTestUser() {
-  const salt = await bcryptjs.genSalt(10);
-  const hashedPassword = await bcryptjs.hash('password123', salt);
+  const hashedPassword = crypto.createHash('sha256').update('password123').digest('hex');
 
   // Limpiamos usuario de prueba existente (Benito)
   await pool.execute('DELETE FROM usuarios WHERE email = ?', ['ferben@correo.com']);
 
-  // Insertamos a Benito Fernandez (Admin) con hash bcrypt
+  // Insertamos a Benito Fernandez (Admin) con hash SHA256
   await pool.execute(
     'INSERT INTO usuarios (documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
     ['51000111', 'Fernandez', 'Benito', 'ferben@correo.com', hashedPassword, '', ROLES.ADMIN, 1],


### PR DESCRIPTION
# refactor: Migración a SHA256 y alineación de campos de login

Este Pull Request resuelve el **Issue #51**, migrando el mecanismo de autenticación para utilizar funciones nativas de la base de datos y estandarizando el naming de los campos del payload.

## Cambios Introducidos

### 1. Migración a MySQL SHA2
- Se eliminó la dependencia de `bcryptjs`.
- La verificación de contraseñas ahora se delega a la base de datos mediante la función nativa `SHA2(?, 256)` en el modelo de usuarios.
- Esto permite cumplir con los requerimientos técnicos de la cátedra manteniendo la lógica criptográfica en el motor SQL.

### 2. Refactor del Payload de Login
- Se renombró el campo `password` a `contrasenia` en:
  - Validadores (`auth.validator.js`).
  - Controladores (`auth.controller.js`).
  - Servicios (`auth.service.js`).
- Este cambio alinea la interfaz de la API con el esquema de la base de datos, reduciendo la fricción en el mapeo de datos.

### 3. Actualización de Seeding y Tests
- Se actualizó `seed.js` para generar hashes SHA256 compatibles usando el módulo `crypto` de Node.js.
- Se actualizaron todos los tests de integración de autenticación para utilizar el nuevo campo `contrasenia`.



## Verificación
- Se ejecutó la suite completa de tests (`npm run test:run`).
- **Resultado:** 35 tests aprobados (se eliminaron los tests específicos de bcrypt que ya no aplican).
- Se verificó manualmente el flujo de login con el usuario de prueba `ferben@correo.com`.

Closes #51
