### PR TITLE
feat/ Obras Sociales - findAll modificado para que se puedan obtener …

### DIFF
--- a/tp-final-integrador/bruno-collection/obras-sociales/Get All (Actives and not actives).bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/Get All (Actives and not actives).bru
@@ -1,0 +1,20 @@
+meta {
+  name: Get All (Actives and not actives)
+  type: http
+  seq: NaN
+}
+
+get {
+  url: {{baseUrl}}/obras-sociales?active=1&active=0
+  body: none
+  auth: inherit
+}
+
+params:query {
+  active: 1
+  active: 0
+}
+
+settings {
+  encodeUrl: true
+}

--- a/tp-final-integrador/bruno-collection/obras-sociales/Get All Actives.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/Get All Actives.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Get All Actives
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}/obras-sociales
+  body: none
+  auth: none
+}

--- a/tp-final-integrador/bruno-collection/obras-sociales/Get All c params.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/Get All c params.bru
@@ -1,31 +1,31 @@
 meta {
-  name: Get All Obras Sociales
+  name: Get All c params
   type: http
   seq: 1
 }
 
 get {
-  url: {{baseUrl}}/obras-sociales?limit=10&offset=0&order=nombre&asc=true&nombre=pami
+  url: {{baseUrl}}/obras-sociales?limit=10&offset=0&order=nombre&asc=true&nombre=OSUNER
   body: none
   auth: none
 }
 
-query {
+params:query {
   limit: 10
   offset: 0
   order: nombre
   asc: true
-  nombre: pami
-}
-
-script:pre-request {
-  const token = bru.getEnvVar('authToken');
-  console.log("authToken desde script:", token);
+  nombre: OSUNER
 }
 
 headers {
   Accept: application/json
   Authorization: Bearer {{authToken}}
+}
+
+script:pre-request {
+  const token = bru.getEnvVar('authToken');
+  console.log("authToken desde script:", token);
 }
 
 docs {

--- a/tp-final-integrador/src/middlewares/query.validator.js
+++ b/tp-final-integrador/src/middlewares/query.validator.js
@@ -21,6 +21,13 @@ export const validateListQuery = (allowedSortFields = [], allowedFilters = []) =
     .toInt()
     .default(0),
 
+  query('active')
+    .optional()
+    .isInt({ min: 0, max: 1 })
+    .withMessage('El param "active" debe ser cero o uno')
+    .toInt()
+    .default(0),
+
   query('order')
     .optional()
     .isIn(allowedSortFields)

--- a/tp-final-integrador/src/modules/obras_sociales/obras_sociales.controller.js
+++ b/tp-final-integrador/src/modules/obras_sociales/obras_sociales.controller.js
@@ -15,7 +15,7 @@ import { ERROR_CODES } from '../../helpers/errors.helper.js';
 
 export const getAll = async (req, res) => {
   const queryParams = matchedData(req, { locations: ['query'] });
-  const { data, total } = await obrasSocialesService.getAllActive(queryParams);
+  const { data, total } = await obrasSocialesService.getAll(queryParams);
   return paginatedResponse(res, data, total, queryParams);
 };
 

--- a/tp-final-integrador/src/modules/obras_sociales/obras_sociales.model.js
+++ b/tp-final-integrador/src/modules/obras_sociales/obras_sociales.model.js
@@ -4,13 +4,20 @@ import { ERROR_CODES } from '../../helpers/errors.helper.js';
 import * as obrasSocialesMapper from './obras_sociales.mapper.js';
 
 /**
- * Retorna todas las obras sociales activas con paginación, orden y filtros.
- * @param {Object} params - Parámetros de búsqueda (limit, offset, order, asc, nombre)
+ * Retorna todas las obras sociales activas o no, con paginación, orden y filtros.
+ * @param {Object} params - Parámetros de búsqueda (limit, offset, order, asc, nombre, active)
  */
-export const findAllActive = async (params = {}) => {
-  const { limit = 10, offset = 0, order = 'id_obra_social', asc = true, nombre } = params;
+export const findAll = async (params = {}) => {
+  const {
+    limit = 10,
+    offset = 0,
+    order = 'id_obra_social',
+    asc = true,
+    nombre,
+    active = 1,
+  } = params;
 
-  const whereClauses = ['activo = 1'];
+  const whereClauses = active === 1 ? ['activo = 1'] : active === 0 ? ['activo = 0'] : [];
   const queryValues = [];
 
   if (nombre) {

--- a/tp-final-integrador/src/modules/obras_sociales/obras_sociales.routes.js
+++ b/tp-final-integrador/src/modules/obras_sociales/obras_sociales.routes.js
@@ -21,7 +21,7 @@ const obrasSocialesRouter = Router();
 obrasSocialesRouter
   .route('/')
   .get(
-    validateListQuery(['id_obra_social', 'nombre', 'porcentaje_descuento'], ['nombre']),
+    validateListQuery(['id_obra_social', 'nombre', 'porcentaje_descuento', 'activo'], ['nombre']),
     validateRequest,
     obrasSocialesController.getAll,
   )

--- a/tp-final-integrador/src/modules/obras_sociales/obras_sociales.service.js
+++ b/tp-final-integrador/src/modules/obras_sociales/obras_sociales.service.js
@@ -4,8 +4,8 @@ import * as obrasSocialesModel from './obras_sociales.model.js';
  * Lógica de negocio para obras sociales.
  */
 
-export const getAllActive = async (params) => {
-  return await obrasSocialesModel.findAllActive(params);
+export const getAll = async (params) => {
+  return await obrasSocialesModel.findAll(params);
 };
 
 export const createObraSocial = async (data) => {

--- a/tp-final-integrador/tests/modules/obras_sociales.service.test.js
+++ b/tp-final-integrador/tests/modules/obras_sociales.service.test.js
@@ -4,7 +4,7 @@ import * as obrasSocialesModel from '../../src/modules/obras_sociales/obras_soci
 
 // Mockeamos el modelo por completo
 vi.mock('../../src/modules/obras_sociales/obras_sociales.model.js', () => ({
-  findAllActive: vi.fn(),
+  findAll: vi.fn(),
   create: vi.fn(),
   findById: vi.fn(),
   update: vi.fn(),
@@ -16,20 +16,20 @@ describe('Obras Sociales - Unit Tests (Service)', () => {
     vi.clearAllMocks(); // Reseteamos los mocks antes de cada test
   });
 
-  describe('getAllActive()', () => {
+  describe('getAll()', () => {
     it('debería retornar las obras sociales del modelo con total', async () => {
       // Configuramos el mock para que devuelva el objeto con data y total
       const mockResult = {
         data: [{ id: 1, nombre: 'OSDE' }],
         total: 1,
       };
-      obrasSocialesModel.findAllActive.mockResolvedValue(mockResult);
+      obrasSocialesModel.findAll.mockResolvedValue(mockResult);
 
       const params = { limit: 10, offset: 0 };
-      const result = await obrasSocialesService.getAllActive(params);
+      const result = await obrasSocialesService.getAll(params);
 
       // Verificamos que se llamó al modelo con los parámetros y que el resultado coincide
-      expect(obrasSocialesModel.findAllActive).toHaveBeenCalledWith(params);
+      expect(obrasSocialesModel.findAll).toHaveBeenCalledWith(params);
       expect(result).toEqual(mockResult);
     });
   });


### PR DESCRIPTION
Se modificó el /Get de obras sociales, para que sea posible visualizar todas las obras sociales, incluidad las no activas.

Por defecto trae las activas, pero con el parámetro 'active=0' en la url se pueden traer las _soft deleted_.

También se actualizaron las collections de bruno para estas busquedas.