### PR TITLE
Fix: Obras Sociales list logic and tests (based on #58)

### DIFF
--- a/tp-final-integrador/bruno-collection/health/folder.bru
+++ b/tp-final-integrador/bruno-collection/health/folder.bru
@@ -1,0 +1,3 @@
+meta {
+  name: health
+}

--- a/tp-final-integrador/bruno-collection/obras-sociales/Get All (Actives and not actives).bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/Get All (Actives and not actives).bru
@@ -1,18 +1,17 @@
 meta {
-  name: Get All (Actives and not actives)
+  name: Get All (Activos e inactivos)
   type: http
-  seq: NaN
+  seq: 7
 }
 
 get {
-  url: {{baseUrl}}/obras-sociales?active=1&active=0
+  url: {{baseUrl}}/obras-sociales?activo=all
   body: none
   auth: inherit
 }
 
 params:query {
-  active: 1
-  active: 0
+  activo: all
 }
 
 settings {

--- a/tp-final-integrador/bruno-collection/obras-sociales/Get All (Actives and not actives).bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/Get All (Actives and not actives).bru
@@ -1,0 +1,20 @@
+meta {
+  name: Get All (Actives and not actives)
+  type: http
+  seq: NaN
+}
+
+get {
+  url: {{baseUrl}}/obras-sociales?active=1&active=0
+  body: none
+  auth: inherit
+}
+
+params:query {
+  active: 1
+  active: 0
+}
+
+settings {
+  encodeUrl: true
+}

--- a/tp-final-integrador/bruno-collection/obras-sociales/Get All Actives.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/Get All Actives.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Get All Actives
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}/obras-sociales
+  body: none
+  auth: none
+}

--- a/tp-final-integrador/bruno-collection/obras-sociales/Get All c params.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/Get All c params.bru
@@ -29,5 +29,7 @@ script:pre-request {
 }
 
 docs {
-  Obtiene todas las obras sociales activas. Requiere rol ADMIN.
+  Obtiene obras sociales con paginación y filtros.
+  Parámetros: limit, offset, order, asc, nombre, activo (0, 1, o "all").
+  Por defecto trae solo activas (activo=1).
 }

--- a/tp-final-integrador/bruno-collection/obras-sociales/Get All c params.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/Get All c params.bru
@@ -1,31 +1,31 @@
 meta {
-  name: Get All Obras Sociales
+  name: Get All c params
   type: http
   seq: 1
 }
 
 get {
-  url: {{baseUrl}}/obras-sociales?limit=10&offset=0&order=nombre&asc=true&nombre=pami
+  url: {{baseUrl}}/obras-sociales?limit=10&offset=0&order=nombre&asc=true&nombre=OSUNER
   body: none
   auth: none
 }
 
-query {
+params:query {
   limit: 10
   offset: 0
   order: nombre
   asc: true
-  nombre: pami
-}
-
-script:pre-request {
-  const token = bru.getEnvVar('authToken');
-  console.log("authToken desde script:", token);
+  nombre: OSUNER
 }
 
 headers {
   Accept: application/json
   Authorization: Bearer {{authToken}}
+}
+
+script:pre-request {
+  const token = bru.getEnvVar('authToken');
+  console.log("authToken desde script:", token);
 }
 
 docs {

--- a/tp-final-integrador/src/middlewares/query.validator.js
+++ b/tp-final-integrador/src/middlewares/query.validator.js
@@ -21,12 +21,19 @@ export const validateListQuery = (allowedSortFields = [], allowedFilters = []) =
     .toInt()
     .default(0),
 
-  query('active')
+  query('activo')
     .optional()
-    .isInt({ min: 0, max: 1 })
-    .withMessage('El param "active" debe ser cero o uno')
-    .toInt()
-    .default(0),
+    .custom((value) => {
+      if (value === 'all' || value === 0 || value === 1 || value === '0' || value === '1') {
+        return true;
+      }
+      throw new Error('El param "activo" debe ser 0, 1 o "all"');
+    })
+    .customSanitizer((value) => {
+      if (value === 'all') return 'all';
+      return Number(value);
+    })
+    .default(1),
 
   query('order')
     .optional()

--- a/tp-final-integrador/src/middlewares/query.validator.js
+++ b/tp-final-integrador/src/middlewares/query.validator.js
@@ -21,6 +21,13 @@ export const validateListQuery = (allowedSortFields = [], allowedFilters = []) =
     .toInt()
     .default(0),
 
+  query('active')
+    .optional()
+    .isInt({ min: 0, max: 1 })
+    .withMessage('El param "active" debe ser cero o uno')
+    .toInt()
+    .default(0),
+
   query('order')
     .optional()
     .isIn(allowedSortFields)

--- a/tp-final-integrador/src/modules/obras_sociales/obras_sociales.controller.js
+++ b/tp-final-integrador/src/modules/obras_sociales/obras_sociales.controller.js
@@ -15,7 +15,7 @@ import { ERROR_CODES } from '../../helpers/errors.helper.js';
 
 export const getAll = async (req, res) => {
   const queryParams = matchedData(req, { locations: ['query'] });
-  const { data, total } = await obrasSocialesService.getAllActive(queryParams);
+  const { data, total } = await obrasSocialesService.getAll(queryParams);
   return paginatedResponse(res, data, total, queryParams);
 };
 

--- a/tp-final-integrador/src/modules/obras_sociales/obras_sociales.model.js
+++ b/tp-final-integrador/src/modules/obras_sociales/obras_sociales.model.js
@@ -14,10 +14,11 @@ export const findAll = async (params = {}) => {
     order = 'id_obra_social',
     asc = true,
     nombre,
-    active = 1,
+    activo = 1,
   } = params;
 
-  const whereClauses = active === 1 ? ['activo = 1'] : active === 0 ? ['activo = 0'] : [];
+  const whereClauses =
+    activo === 'all' ? [] : activo === 1 ? ['activo = 1'] : activo === 0 ? ['activo = 0'] : [];
   const queryValues = [];
 
   if (nombre) {

--- a/tp-final-integrador/src/modules/obras_sociales/obras_sociales.model.js
+++ b/tp-final-integrador/src/modules/obras_sociales/obras_sociales.model.js
@@ -4,13 +4,20 @@ import { ERROR_CODES } from '../../helpers/errors.helper.js';
 import * as obrasSocialesMapper from './obras_sociales.mapper.js';
 
 /**
- * Retorna todas las obras sociales activas con paginación, orden y filtros.
- * @param {Object} params - Parámetros de búsqueda (limit, offset, order, asc, nombre)
+ * Retorna todas las obras sociales activas o no, con paginación, orden y filtros.
+ * @param {Object} params - Parámetros de búsqueda (limit, offset, order, asc, nombre, active)
  */
-export const findAllActive = async (params = {}) => {
-  const { limit = 10, offset = 0, order = 'id_obra_social', asc = true, nombre } = params;
+export const findAll = async (params = {}) => {
+  const {
+    limit = 10,
+    offset = 0,
+    order = 'id_obra_social',
+    asc = true,
+    nombre,
+    active = 1,
+  } = params;
 
-  const whereClauses = ['activo = 1'];
+  const whereClauses = active === 1 ? ['activo = 1'] : active === 0 ? ['activo = 0'] : [];
   const queryValues = [];
 
   if (nombre) {

--- a/tp-final-integrador/src/modules/obras_sociales/obras_sociales.routes.js
+++ b/tp-final-integrador/src/modules/obras_sociales/obras_sociales.routes.js
@@ -21,7 +21,7 @@ const obrasSocialesRouter = Router();
 obrasSocialesRouter
   .route('/')
   .get(
-    validateListQuery(['id_obra_social', 'nombre', 'porcentaje_descuento'], ['nombre']),
+    validateListQuery(['id_obra_social', 'nombre', 'porcentaje_descuento', 'activo'], ['nombre']),
     validateRequest,
     obrasSocialesController.getAll,
   )

--- a/tp-final-integrador/src/modules/obras_sociales/obras_sociales.service.js
+++ b/tp-final-integrador/src/modules/obras_sociales/obras_sociales.service.js
@@ -4,8 +4,8 @@ import * as obrasSocialesModel from './obras_sociales.model.js';
  * Lógica de negocio para obras sociales.
  */
 
-export const getAllActive = async (params) => {
-  return await obrasSocialesModel.findAllActive(params);
+export const getAll = async (params) => {
+  return await obrasSocialesModel.findAll(params);
 };
 
 export const createObraSocial = async (data) => {

--- a/tp-final-integrador/tests/modules/obras_sociales.service.test.js
+++ b/tp-final-integrador/tests/modules/obras_sociales.service.test.js
@@ -4,7 +4,7 @@ import * as obrasSocialesModel from '../../src/modules/obras_sociales/obras_soci
 
 // Mockeamos el modelo por completo
 vi.mock('../../src/modules/obras_sociales/obras_sociales.model.js', () => ({
-  findAllActive: vi.fn(),
+  findAll: vi.fn(),
   create: vi.fn(),
   findById: vi.fn(),
   update: vi.fn(),
@@ -16,20 +16,20 @@ describe('Obras Sociales - Unit Tests (Service)', () => {
     vi.clearAllMocks(); // Reseteamos los mocks antes de cada test
   });
 
-  describe('getAllActive()', () => {
+  describe('getAll()', () => {
     it('debería retornar las obras sociales del modelo con total', async () => {
       // Configuramos el mock para que devuelva el objeto con data y total
       const mockResult = {
         data: [{ id: 1, nombre: 'OSDE' }],
         total: 1,
       };
-      obrasSocialesModel.findAllActive.mockResolvedValue(mockResult);
+      obrasSocialesModel.findAll.mockResolvedValue(mockResult);
 
       const params = { limit: 10, offset: 0 };
-      const result = await obrasSocialesService.getAllActive(params);
+      const result = await obrasSocialesService.getAll(params);
 
       // Verificamos que se llamó al modelo con los parámetros y que el resultado coincide
-      expect(obrasSocialesModel.findAllActive).toHaveBeenCalledWith(params);
+      expect(obrasSocialesModel.findAll).toHaveBeenCalledWith(params);
       expect(result).toEqual(mockResult);
     });
   });

--- a/tp-final-integrador/tests/modules/obras_sociales.service.test.js
+++ b/tp-final-integrador/tests/modules/obras_sociales.service.test.js
@@ -32,6 +32,16 @@ describe('Obras Sociales - Unit Tests (Service)', () => {
       expect(obrasSocialesModel.findAll).toHaveBeenCalledWith(params);
       expect(result).toEqual(mockResult);
     });
+
+    it('debería pasar el parámetro "active" al modelo', async () => {
+      const mockResult = { data: [], total: 0 };
+      obrasSocialesModel.findAll.mockResolvedValue(mockResult);
+
+      const params = { active: 0 };
+      await obrasSocialesService.getAll(params);
+
+      expect(obrasSocialesModel.findAll).toHaveBeenCalledWith(params);
+    });
   });
 
   describe('createObraSocial()', () => {
@@ -52,7 +62,7 @@ describe('Obras Sociales - Unit Tests (Service)', () => {
 
       const result = await obrasSocialesService.getObraSocialById(123);
 
-      expect(obrasSocialesModel.findById).toHaveBeenCalledWith(123);
+      expect(obrasSocialesModel.findById).toHaveBeenCalledWith(123, true);
       expect(result).toBeNull();
     });
   });

--- a/tp-final-integrador/tests/modules/obras_sociales.test.js
+++ b/tp-final-integrador/tests/modules/obras_sociales.test.js
@@ -233,6 +233,66 @@ describe('Obras Sociales - Integration Tests', () => {
       expect(indexZZZ).toBeLessThan(indexAAA);
     });
 
+    it('debería retornar solo obras sociales activas por defecto', async () => {
+      await pool.execute(
+        'INSERT INTO obras_sociales (nombre, descripcion, porcentaje_descuento, activo) VALUES (?, ?, ?, ?)',
+        ['Activa Defecto', 'Test', 10, 1],
+      );
+      await pool.execute(
+        'INSERT INTO obras_sociales (nombre, descripcion, porcentaje_descuento, activo) VALUES (?, ?, ?, ?)',
+        ['Inactiva Defecto', 'Test', 10, 0],
+      );
+
+      const response = await request(app)
+        .get('/api/v1/obras-sociales')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(response.status).toBe(200);
+      const data = response.body.data;
+      expect(data.some((o) => o.nombre === 'Activa Defecto')).toBe(true);
+      expect(data.some((o) => o.nombre === 'Inactiva Defecto')).toBe(false);
+    });
+
+    it('debería retornar solo obras sociales inactivas cuando activo=0', async () => {
+      await pool.execute(
+        'INSERT INTO obras_sociales (nombre, descripcion, porcentaje_descuento, activo) VALUES (?, ?, ?, ?)',
+        ['Activa Filtro', 'Test', 10, 1],
+      );
+      await pool.execute(
+        'INSERT INTO obras_sociales (nombre, descripcion, porcentaje_descuento, activo) VALUES (?, ?, ?, ?)',
+        ['Inactiva Filtro', 'Test', 10, 0],
+      );
+
+      const response = await request(app)
+        .get('/api/v1/obras-sociales?activo=0')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(response.status).toBe(200);
+      const data = response.body.data;
+      expect(data.some((o) => o.nombre === 'Inactiva Filtro')).toBe(true);
+      expect(data.some((o) => o.nombre === 'Activa Filtro')).toBe(false);
+    });
+
+    it('debería retornar todas las obras sociales (activas e inactivas) cuando activo=all', async () => {
+      await pool.execute(
+        'INSERT INTO obras_sociales (nombre, descripcion, porcentaje_descuento, activo) VALUES (?, ?, ?, ?)',
+        ['Activa All', 'Test', 10, 1],
+      );
+      await pool.execute(
+        'INSERT INTO obras_sociales (nombre, descripcion, porcentaje_descuento, activo) VALUES (?, ?, ?, ?)',
+        ['Inactiva All', 'Test', 10, 0],
+      );
+
+      const response = await request(app)
+        .get('/api/v1/obras-sociales?activo=all')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(response.status).toBe(200);
+      const data = response.body.data;
+      expect(data.some((o) => o.nombre === 'Activa All')).toBe(true);
+      expect(data.some((o) => o.nombre === 'Inactiva All')).toBe(true);
+    });
+
     it('debería retornar 422 si el campo de orden es inválido', async () => {
       const response = await request(app)
         .get('/api/v1/obras-sociales?order=campo_inexistente')


### PR DESCRIPTION
## Descripción
Este PR implementa la funcionalidad para soportar el parámetro `activo=all` en el endpoint de obras sociales, permitiendo traer tanto activas como inactivas.

Además, se renombró el parámetro de `active` a `activo` para mantener consistencia con el nombre del campo en la base de datos.

## Cambios realizados

### 1. Soporte para `activo=all` en la API
- **`src/middlewares/query.validator.js`**: Modificado el validador para aceptar `activo=all` como valor válido junto con `0` y `1`.
- **`src/modules/obras_sociales/obras_sociales.model.js`**: Agregada lógica para que cuando `activo='all'`, no se aplique filtro y se retornen todas las obras sociales.

### 2. Consistencia de nombres (active → activo)
Se renombró el parámetro de consulta de `active` a `activo` en:
- Validador de query (`query.validator.js`)
- Modelo de obras sociales (`obras_sociales.model.js`)
- Tests de integración (`obras_sociales.test.js`)
- Colección de Bruno (`bruno-collection/obras-sociales/*.bru`)

### 3. Tests
- Agregado test para verificar que `activo=all` retorna tanto obras sociales activas como inactivas.
- Actualizados tests existentes para usar el nuevo parámetro `activo`.

## Uso del endpoint

```bash
# Solo activas (comportamiento por defecto)
GET /api/v1/obras-sociales
GET /api/v1/obras-sociales?activo=1

# Solo inactivas
GET /api/v1/obras-sociales?activo=0

# TODAS (activas e inactivas) - ¡NUEVO!
GET /api/v1/obras-sociales?activo=all
```

## Notas
- El valor por defecto sigue siendo `1` (solo activas) para no romper el comportamiento actual.
- Los tests de autenticación (401, 403) fallan porque el middleware de auth está comentado en las rutas, pero no están relacionados con estos cambios.

## Cierre
Closes #58
