### PR TITLE
fix(middlewares): permitir multipart/form-data en validación de contenido

### DIFF
--- a/tp-final-integrador/src/middlewares/content.middleware.js
+++ b/tp-final-integrador/src/middlewares/content.middleware.js
@@ -13,10 +13,11 @@ const validateContentType = (req, res, next) => {
   if (!hasBody) return next();
 
   const contentType = req.headers['content-type'];
+  const allowedTypes = ['application/json', 'multipart/form-data'];
 
   if (
     ['POST', 'PUT', 'PATCH'].includes(req.method) &&
-    (!contentType || !contentType.startsWith('application/json'))
+    (!contentType || !allowedTypes.some((type) => contentType.startsWith(type)))
   ) {
     return errorResponse({ res, errorType: ERROR_CODES.UNSUPPORTED_MEDIA_TYPE });
   }


### PR DESCRIPTION
Closes #63

### Tipo de cambio
- [x] Corrección de error (Bug fix)

### Resumen
- Se actualizó el middleware de contenido para permitir el tipo de medio 'multipart/form-data'.
- Esto evita bloqueos innecesarios al intentar subir archivos (ej. fotos de perfil) usando Multer.

### Tabla de cambios
| Archivo | Cambio |
| :--- | :--- |
| tp-final-integrador/src/middlewares/content.middleware.js | Se agregó 'multipart/form-data' a la lista de tipos permitidos. |

### Plan de prueba
- [x] Verificado manualmente que las peticiones JSON siguen funcionando.
- [x] Verificado que el código permite el inicio de tipos multipart.