### PR TITLE
fix(obras-sociales): filtrar registros inactivos en getById

### DIFF
--- a/tp-final-integrador/src/controllers/obras_sociales.controller.js
+++ b/tp-final-integrador/src/controllers/obras_sociales.controller.js
@@ -17,10 +17,8 @@ export const getAll = async (req, res) => {
 
 export const getById = async (req, res) => {
   const { id } = matchedData(req);
-  // Buscamos incluyendo inactivas (onlyActive = false) ya que este módulo
-  // es de gestión exclusiva para el Administrador, quien debe poder
-  // visualizar y reactivar registros borrados lógicamente.
-  const obraSocial = await obrasSocialesService.getObraSocialById(id, false);
+  // Por defecto solo buscamos obras sociales activas.
+  const obraSocial = await obrasSocialesService.getObraSocialById(id);
 
   if (!obraSocial) {
     return errorResponse({ res, errorType: ERROR_CODES.NOT_FOUND });

--- a/tp-final-integrador/tests/modules/obras_sociales.test.js
+++ b/tp-final-integrador/tests/modules/obras_sociales.test.js
@@ -303,6 +303,47 @@ describe('Obras Sociales - Integration Tests', () => {
     });
   });
 
+  describe('GET /api/v1/obras-sociales/:id', () => {
+    it('debería retornar los datos de una obra social activa', async () => {
+      const [result] = await pool.execute(
+        'INSERT INTO obras_sociales (nombre, descripcion, porcentaje_descuento, activo) VALUES (?, ?, ?, ?)',
+        ['Obra Por ID', 'Test', 0, 1],
+      );
+      const id = result.insertId;
+
+      const response = await request(app)
+        .get(`/api/v1/obras-sociales/${id}`)
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.id).toBe(id);
+      expect(response.body.data.nombre).toBe('Obra Por ID');
+    });
+
+    it('debería retornar 404 si la obra social está inactiva', async () => {
+      const [result] = await pool.execute(
+        'INSERT INTO obras_sociales (nombre, descripcion, porcentaje_descuento, activo) VALUES (?, ?, ?, ?)',
+        ['Obra Inactiva ID', 'Test', 0, 0],
+      );
+      const id = result.insertId;
+
+      const response = await request(app)
+        .get(`/api/v1/obras-sociales/${id}`)
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(response.status).toBe(404);
+      expect(response.body.success).toBe(false);
+    });
+
+    it('debería retornar 404 si la obra social no existe', async () => {
+      const response = await request(app)
+        .get('/api/v1/obras-sociales/999999')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(response.status).toBe(404);
+    });
+  });
+
   describe('DELETE /api/v1/obras-sociales/:id', () => {
     it('debería realizar un borrado lógico (activo = 0) en la base de datos', async () => {
       const [result] = await pool.execute(


### PR DESCRIPTION
## Descripción
Se corrigió el error donde el endpoint GET /api/v1/obras-sociales/:id retornaba registros inactivos (activo = 0).

## Cambios
- Se modificó src/controllers/obras_sociales.controller.js para que la llamada al servicio use el filtro de registros activos por defecto.
- Se agregaron tests de integración en tests/modules/obras_sociales.test.js para cubrir los escenarios de:
  - Registro activo (200 OK)
  - Registro inactivo (404 Not Found)
  - Registro inexistente (404 Not Found)