### PR TITLE
chore(logging): persistir peticiones en access.log

### DIFF
--- a/tp-final-integrador/.gitignore
+++ b/tp-final-integrador/.gitignore
@@ -36,3 +36,6 @@ build/
 # Uploads
 public/uploads/**
 !public/uploads/**/.gitkeep
+
+# logs
+logs/

--- a/tp-final-integrador/src/app.js
+++ b/tp-final-integrador/src/app.js
@@ -5,7 +5,8 @@ import morgan from 'morgan';
 import apiRouter from './routes/index.js';
 import { notFoundHandler, globalErrorHandler } from './middlewares/error.middleware.js';
 import validateContentType from './middlewares/content.middleware.js';
-
+import fs from 'node:fs';
+import path from 'node:path';
 const app = express();
 
 // Middlewares base
@@ -19,6 +20,11 @@ app.use(
 
 if (process.env.NODE_ENV !== 'test') {
   app.use(morgan('dev'));
+  fs.mkdirSync(path.join(process.cwd(), 'logs'), { recursive: true });
+  const accessLogStream = fs.createWriteStream(path.join(process.cwd(), 'logs', 'access.log'), {
+    flags: 'a',
+  });
+  app.use(morgan('combined', { stream: accessLogStream }));
 }
 
 app.use(validateContentType);


### PR DESCRIPTION
## Resumen
Implementación de persistencia de logs de peticiones HTTP utilizando Morgan y Node FS. Esto facilita la auditoría y depuración en entornos de desarrollo y producción sin depender únicamente de la consola.

## Tabla de Cambios
| Archivo | Cambio |
|------|--------|
| `tp-final-integrador/src/app.js` | Se configuró Morgan con el formato 'combined' y un stream de escritura hacia `logs/access.log`. |
| `tp-final-integrador/.gitignore` | Se agregó el directorio `logs/` para evitar que los archivos de log sean trackeados por git. |

## Plan de Pruebas
- [x] Se verificó que el archivo `logs/access.log` se cree automáticamente en modo development.
- [x] Se verificó que el logging sea silencioso durante la ejecución de tests (`npm run test:run`).
- [x] Los 99 tests existentes pasaron correctamente.