### PR TITLE
feat(cache): agregar middleware de caché con apicache e invalidación por grupos

### DIFF
--- a/tp-final-integrador/package-lock.json
+++ b/tp-final-integrador/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "apicache": "1.6.3",
         "bcryptjs": "3.0.3",
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -1073,6 +1074,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/apicache": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/apicache/-/apicache-1.6.3.tgz",
+      "integrity": "sha512-jS3VfUFpQ9BesFQZcdd1vVYg3ZsO2kGPmTJHqycIYPAQs54r74CRiyj8DuzJpwzLwIfCBYzh4dy9Jt8xYbo27w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/append-field": {

--- a/tp-final-integrador/package.json
+++ b/tp-final-integrador/package.json
@@ -24,6 +24,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "apicache": "1.6.3",
     "bcryptjs": "3.0.3",
     "cors": "2.8.6",
     "express": "5.2.1",

--- a/tp-final-integrador/src/middlewares/cache.middleware.js
+++ b/tp-final-integrador/src/middlewares/cache.middleware.js
@@ -1,0 +1,70 @@
+import apicache from 'apicache';
+
+// Configuración global de apicache
+apicache.options({
+  debug: false,
+  statusCodes: {
+    include: [200],
+  },
+});
+
+/**
+ * Duraciones predefinidas para el cache
+ */
+export const CACHE_DURATIONS = {
+  SHORT: '5 minutes',
+  MEDIUM: '15 minutes',
+  LONG: '1 hour',
+};
+
+/**
+ * Helper para verificar si la caché está activa en el entorno actual
+ * @returns {boolean}
+ */
+const isCacheEnabled = () => {
+  return process.env.NODE_ENV !== 'test' || process.env.ENABLE_CACHE === 'true';
+};
+
+/**
+ * Middleware para cachear respuestas
+ * @param {string} duration - Duración del cache (e.g. '5 minutes')
+ * @param {string} group - Grupo al que pertenece el cache para invalidación selectiva
+ */
+export const cacheMiddleware = (duration, group) => {
+  return (req, res, next) => {
+    if (!isCacheEnabled()) {
+      return next();
+    }
+
+    // Parcheamos temporalmente setHeader para obligar a apicache a mandar 'no-cache' en el Hit
+    const originalSetHeader = res.setHeader;
+    res.setHeader = function (name, value) {
+      if (name.toLowerCase() === 'cache-control') {
+        return originalSetHeader.call(this, name, 'no-cache');
+      }
+      return originalSetHeader.call(this, name, value);
+    };
+
+    req.apicacheGroup = group;
+    return apicache.middleware(duration)(req, res, next);
+  };
+};
+
+/**
+ * Middleware para limpiar el cache de un grupo específico
+ * @param {string} group - Grupo a limpiar
+ */
+export const clearCacheMiddleware = (group) => {
+  return (req, res, next) => {
+    if (!isCacheEnabled()) {
+      return next();
+    }
+
+    res.on('finish', () => {
+      if (res.statusCode >= 200 && res.statusCode < 300) {
+        apicache.clear(group);
+      }
+    });
+    next();
+  };
+};

--- a/tp-final-integrador/src/routes/obras_sociales.routes.js
+++ b/tp-final-integrador/src/routes/obras_sociales.routes.js
@@ -5,6 +5,11 @@ import { validateListQuery } from '../middlewares/query.validator.js';
 // import { ROLES } from '../constants/roles.constants.js';
 // import { verifyToken, requireRole } from '../middlewares/auth.middleware.js';
 import { validateRequest } from '../middlewares/validate.middleware.js';
+import {
+  cacheMiddleware,
+  clearCacheMiddleware,
+  CACHE_DURATIONS,
+} from '../middlewares/cache.middleware.js';
 import { methodNotAllowedHandler } from '../middlewares/method-not-allowed.middleware.js';
 
 const obrasSocialesRouter = Router();
@@ -21,11 +26,13 @@ const obrasSocialesRouter = Router();
 obrasSocialesRouter
   .route('/')
   .get(
+    cacheMiddleware(CACHE_DURATIONS.SHORT, 'obras-sociales'),
     validateListQuery(['id', 'nombre', 'porcentajeDescuento', 'activo'], ['nombre']),
     validateRequest,
     obrasSocialesController.getAll,
   )
   .post(
+    clearCacheMiddleware('obras-sociales'),
     obrasSocialesValidator.validateCreate,
     validateRequest,
     obrasSocialesController.createObraSocial,
@@ -34,13 +41,20 @@ obrasSocialesRouter
 
 obrasSocialesRouter
   .route('/:id')
-  .get(obrasSocialesValidator.validateId, validateRequest, obrasSocialesController.getById)
+  .get(
+    cacheMiddleware(CACHE_DURATIONS.SHORT, 'obras-sociales'),
+    obrasSocialesValidator.validateId,
+    validateRequest,
+    obrasSocialesController.getById,
+  )
   .put(
+    clearCacheMiddleware('obras-sociales'),
     obrasSocialesValidator.validateUpdate,
     validateRequest,
     obrasSocialesController.updateObraSocial,
   )
   .delete(
+    clearCacheMiddleware('obras-sociales'),
     obrasSocialesValidator.validateId,
     validateRequest,
     obrasSocialesController.removeObraSocial,

--- a/tp-final-integrador/tests/middlewares/cache.middleware.test.js
+++ b/tp-final-integrador/tests/middlewares/cache.middleware.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import apicache from 'apicache';
+import {
+  cacheMiddleware,
+  clearCacheMiddleware,
+  CACHE_DURATIONS,
+} from '../../src/middlewares/cache.middleware.js';
+
+vi.mock('apicache', () => {
+  const mockMiddleware = vi.fn(() => (req, res, next) => next());
+  return {
+    default: {
+      options: vi.fn().mockReturnThis(),
+      middleware: mockMiddleware,
+      clear: vi.fn(),
+    },
+  };
+});
+
+describe('Cache Middleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ENABLE_CACHE = 'true';
+  });
+
+  afterAll(() => {
+    delete process.env.ENABLE_CACHE;
+  });
+
+  it('debería exportar duraciones de cache correctas', () => {
+    expect(CACHE_DURATIONS.SHORT).toBe('5 minutes');
+    expect(CACHE_DURATIONS.MEDIUM).toBe('15 minutes');
+    expect(CACHE_DURATIONS.LONG).toBe('1 hour');
+  });
+
+  it('cacheMiddleware debería asignar el grupo y llamar a apicache.middleware', () => {
+    const req = {};
+    const res = {};
+    const next = vi.fn();
+    const group = 'test-group';
+    const duration = CACHE_DURATIONS.SHORT;
+
+    const middleware = cacheMiddleware(duration, group);
+    middleware(req, res, next);
+
+    expect(req.apicacheGroup).toBe(group);
+    expect(apicache.middleware).toHaveBeenCalledWith(duration);
+  });
+
+  it('clearCacheMiddleware debería llamar a apicache.clear al finalizar la respuesta exitosa', () => {
+    const req = {};
+    const res = {
+      statusCode: 200,
+      on: vi.fn((event, cb) => {
+        if (event === 'finish') {
+          // Simulamos que el evento finish ocurre
+          cb();
+        }
+      }),
+    };
+    const next = vi.fn();
+    const group = 'test-group';
+
+    const middleware = clearCacheMiddleware(group);
+    middleware(req, res, next);
+
+    expect(res.on).toHaveBeenCalledWith('finish', expect.any(Function));
+    expect(apicache.clear).toHaveBeenCalledWith(group);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('clearCacheMiddleware NO debería llamar a apicache.clear si la respuesta falla', () => {
+    const req = {};
+    const res = {
+      statusCode: 400,
+      on: vi.fn((event, cb) => {
+        if (event === 'finish') {
+          cb();
+        }
+      }),
+    };
+    const next = vi.fn();
+    const group = 'test-group';
+
+    const middleware = clearCacheMiddleware(group);
+    middleware(req, res, next);
+
+    expect(apicache.clear).not.toHaveBeenCalled();
+  });
+});

--- a/tp-final-integrador/tests/modules/cache.integration.test.js
+++ b/tp-final-integrador/tests/modules/cache.integration.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { app } from '../../src/app.js';
+import { setupTestDB } from '../setup/db.js';
+import { ROLES } from '../../src/constants/roles.constants.js';
+import apicache from 'apicache';
+
+describe('Cache Integration Tests', () => {
+  let adminToken;
+  const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+
+  beforeEach(async () => {
+    process.env.ENABLE_CACHE = 'true';
+    apicache.clear(); // Limpiamos cache global entre tests
+    await setupTestDB();
+    adminToken = jwt.sign({ id: 8, rol: ROLES.ADMIN, documento: '51000111' }, JWT_SECRET);
+  });
+
+  afterAll(() => {
+    delete process.env.ENABLE_CACHE;
+  });
+
+  it('debería guardar la respuesta en el cache en la primera petición GET', async () => {
+    // Verificamos que el índice está vacío al inicio
+    apicache.clear();
+    expect(Object.keys(apicache.getIndex().all).length).toBe(0);
+
+    // Primera petición (MISS)
+    await request(app).get('/api/v1/obras-sociales').set('Authorization', `Bearer ${adminToken}`);
+
+    // Damos un respiro para que apicache guarde (es asíncrono al res.end)
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Verificamos que ahora hay una entrada en el cache
+    const index = apicache.getIndex();
+    expect(Object.keys(index.all).length).toBeGreaterThan(0);
+  });
+
+  it('debería invalidar el cache después de un POST', async () => {
+    // 1. Llenamos cache
+    await request(app).get('/api/v1/obras-sociales').set('Authorization', `Bearer ${adminToken}`);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(Object.keys(apicache.getIndex().all).length).toBeGreaterThan(0);
+
+    // 2. Creamos nueva obra social (debería limpiar cache)
+    await request(app)
+      .post('/api/v1/obras-sociales')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        nombre: 'Nueva OS Cache Inval',
+        descripcion: 'Test cache invalidation',
+        porcentajeDescuento: 10,
+        esParticular: false,
+      });
+
+    // 3. El índice de cache para el grupo 'obras-sociales' debería estar vacío
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(Object.keys(apicache.getIndex().all).length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Descripción

Implementación de un middleware de caché HTTP usando apicache con soporte para invalidación selectiva por grupos.

## Tipo de cambio

- [x] Nueva funcionalidad

## Resumen

- Se agrega `cacheMiddleware` con duración configurable y soporte de grupos para invalidación selectiva
- Se agrega `clearCacheMiddleware` que invalida el caché al finalizar mutaciones exitosas (2xx)
- Se integra el caché en las rutas GET de obras sociales con duración corta (5 minutos)

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| `src/middlewares/cache.middleware.js` | Nuevo — middleware de caché y limpieza |
| `src/routes/obras_sociales.routes.js` | Integración de `cacheMiddleware` y `clearCacheMiddleware` |
| `tests/middlewares/cache.middleware.test.js` | Nuevo — tests unitarios del middleware |
| `tests/modules/cache.integration.test.js` | Nuevo — tests de integración del caché |
| `package.json` | Dependencia `apicache@1.6.3` |