### PR TITLE
feat(turnos): registro de turno - reservas

### DIFF
--- a/tp-final-integrador/bruno-collection/turnos/error-fecha-pasada.bru
+++ b/tp-final-integrador/bruno-collection/turnos/error-fecha-pasada.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Error - Fecha Pasada
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/turnos
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "idMedico": 1,
+    "idPaciente": 1,
+    "idObraSocial": 1,
+    "fecha": "2020-01-01",
+    "hora": "10:00"
+  }
+}
+
+docs {
+  Prueba de validación: el sistema debe retornar 422 si la fecha es anterior a la actual.
+}

--- a/tp-final-integrador/bruno-collection/turnos/folder.bru
+++ b/tp-final-integrador/bruno-collection/turnos/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: Turnos Reserva
+  type: "folder"
+}
+
+auth {
+  mode: "bearer"
+}

--- a/tp-final-integrador/bruno-collection/turnos/registrar-obra-social.bru
+++ b/tp-final-integrador/bruno-collection/turnos/registrar-obra-social.bru
@@ -25,5 +25,5 @@ docs {
 
   **Cálculo de valor_total**:
   Si la obra social NO es particular, se aplica el descuento:
-  `valor_total = valor_consulta - (porcentaje_descuento * valor_consulta / 100)`
+  `valor_total = valor_consulta - (porcentaje_descuento * valor_consulta)`
 }

--- a/tp-final-integrador/bruno-collection/turnos/registrar-obra-social.bru
+++ b/tp-final-integrador/bruno-collection/turnos/registrar-obra-social.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Registrar Turno (Obra Social)
+  type: "http"
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/turnos
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "idMedico": 1,
+    "idPaciente": 1,
+    "idObraSocial": 1,
+    "fecha": "2026-07-15",
+    "hora": "14:30"
+  }
+}
+
+docs {
+  Registra un nuevo turno para un paciente con un médico y obra social.
+
+  **Cálculo de valor_total**:
+  Si la obra social NO es particular, se aplica el descuento:
+  `valor_total = valor_consulta - (porcentaje_descuento * valor_consulta / 100)`
+}

--- a/tp-final-integrador/bruno-collection/turnos/registrar-particular.bru
+++ b/tp-final-integrador/bruno-collection/turnos/registrar-particular.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Registrar Turno (Particular)
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/turnos
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "idMedico": 1,
+    "idPaciente": 1,
+    "idObraSocial": 6,
+    "fecha": "2026-07-16",
+    "hora": "09:00"
+  }
+}
+
+docs {
+  Registra un nuevo turno para un paciente con un médico y obra social particular.
+
+  **Cálculo de valor_total**:
+  Si la obra social ES particular, se cobra el `valor_consulta` neto del médico.
+}

--- a/tp-final-integrador/docs/ENDPOINTS.md
+++ b/tp-final-integrador/docs/ENDPOINTS.md
@@ -37,12 +37,30 @@ Este documento detalla los endpoints disponibles en la API para facilitar las pr
 
 ---
 
+## 📅 Turnos (`/turnos`)
+
+| Método | Endpoint | Descripción | Acceso |
+| :--- | :--- | :--- | :--- |
+| `POST` | `/api/v1/turnos` | Registrar un nuevo turno | Admin |
+
+### Cuerpo de la Petición (Payload JSON)
+```json
+{
+  "idMedico": 1,
+  "idPaciente": 1,
+  "idObraSocial": 1,
+  "fecha": "2026-07-15",
+  "hora": "14:30"
+}
+```
+
+---
+
 ## 🚀 Próximamente
 
 Los siguientes módulos están en desarrollo:
 - **Médicos**: Gestión de profesionales y especialidades.
 - **Pacientes**: Gestión de perfiles y obras sociales.
-- **Turnos**: Sistema de reserva y agenda médica.
 
 ---
 

--- a/tp-final-integrador/src/constants/routes.constants.js
+++ b/tp-final-integrador/src/constants/routes.constants.js
@@ -11,4 +11,5 @@ export const ROUTES = {
   HEALTH: '/health',
   AUTH: '/auth',
   OBRAS_SOCIALES: '/obras-sociales',
+  TURNOS: '/turnos',
 };

--- a/tp-final-integrador/src/controllers/turnos.controller.js
+++ b/tp-final-integrador/src/controllers/turnos.controller.js
@@ -1,0 +1,14 @@
+import { matchedData } from 'express-validator';
+import * as turnosService from '../services/turnos.service.js';
+import { successResponse } from '../helpers/response.helper.js';
+
+/**
+ * Controlador para la gestión de turnos.
+ */
+
+export const registrarTurno = async (req, res) => {
+  const data = matchedData(req);
+  const nuevoTurno = await turnosService.registrarTurno(data);
+
+  return successResponse(res, nuevoTurno, 201);
+};

--- a/tp-final-integrador/src/database/medicos.js
+++ b/tp-final-integrador/src/database/medicos.js
@@ -1,4 +1,5 @@
 import { pool } from '../config/db.js';
+import { DB_STATUS } from '../constants/common.constants.js';
 import * as medicosMapper from './medicos.mapper.js';
 
 /**
@@ -28,8 +29,8 @@ export const findById = async (id) => {
 export const acceptsObraSocial = async (idMedico, idObraSocial) => {
   const query = `
     SELECT 1 FROM medicos_obras_sociales
-    WHERE id_medico = ? AND id_obra_social = ? AND activo = 1
+    WHERE id_medico = ? AND id_obra_social = ? AND activo = ?
   `;
-  const [rows] = await pool.execute(query, [idMedico, idObraSocial]);
+  const [rows] = await pool.execute(query, [idMedico, idObraSocial, DB_STATUS.ACTIVE]);
   return rows.length > 0;
 };

--- a/tp-final-integrador/src/database/medicos.js
+++ b/tp-final-integrador/src/database/medicos.js
@@ -1,0 +1,35 @@
+import { pool } from '../config/db.js';
+import * as medicosMapper from './medicos.mapper.js';
+
+/**
+ * Busca un médico por su ID.
+ * @param {number} id
+ * @returns {Promise<Object|null>}
+ */
+export const findById = async (id) => {
+  const query = `
+    SELECT m.id_medico, m.id_usuario, m.id_especialidad, m.matricula, m.valor_consulta, u.activo
+    FROM medicos m
+    JOIN usuarios u ON m.id_usuario = u.id_usuario
+    WHERE m.id_medico = ?
+  `;
+  const [rows] = await pool.execute(query, [id]);
+
+  if (rows.length === 0) return null;
+  return medicosMapper.toDTO(rows[0]);
+};
+
+/**
+ * Verifica si un médico atiende una obra social específica de forma activa.
+ * @param {number} idMedico
+ * @param {number} idObraSocial
+ * @returns {Promise<boolean>}
+ */
+export const acceptsObraSocial = async (idMedico, idObraSocial) => {
+  const query = `
+    SELECT 1 FROM medicos_obras_sociales
+    WHERE id_medico = ? AND id_obra_social = ? AND activo = 1
+  `;
+  const [rows] = await pool.execute(query, [idMedico, idObraSocial]);
+  return rows.length > 0;
+};

--- a/tp-final-integrador/src/database/medicos.mapper.js
+++ b/tp-final-integrador/src/database/medicos.mapper.js
@@ -1,0 +1,32 @@
+/**
+ * Mapper para el módulo de Médicos.
+ * Convierte registros de la base de datos (snake_case) a objetos de transferencia de datos (DTO) en camelCase.
+ */
+
+/**
+ * Mapea una fila de la base de datos a un DTO de Médico.
+ * @param {Object} row - Fila de la base de datos.
+ * @returns {Object} DTO en camelCase.
+ */
+export const toDTO = (row) => {
+  if (!row) return null;
+
+  return {
+    idMedico: row.id_medico,
+    idUsuario: row.id_usuario,
+    idEspecialidad: row.id_especialidad,
+    matricula: row.matricula,
+    valorConsulta: row.valor_consulta !== null ? Number(row.valor_consulta) : 0,
+    activo: !!row.activo,
+  };
+};
+
+/**
+ * Mapea una lista de filas de la base de datos a una lista de DTOs.
+ * @param {Array} rows - Lista de filas.
+ * @returns {Array} Lista de DTOs.
+ */
+export const toDTOList = (rows) => {
+  if (!rows || !Array.isArray(rows)) return [];
+  return rows.map(toDTO);
+};

--- a/tp-final-integrador/src/database/pacientes.js
+++ b/tp-final-integrador/src/database/pacientes.js
@@ -1,0 +1,20 @@
+import { pool } from '../config/db.js';
+import * as pacientesMapper from './pacientes.mapper.js';
+
+/**
+ * Busca un paciente por su ID.
+ * @param {number} id
+ * @returns {Promise<Object|null>}
+ */
+export const findById = async (id) => {
+  const query = `
+    SELECT p.id_paciente, p.id_usuario, p.id_obra_social, u.activo
+    FROM pacientes p
+    JOIN usuarios u ON p.id_usuario = u.id_usuario
+    WHERE p.id_paciente = ?
+  `;
+  const [rows] = await pool.execute(query, [id]);
+
+  if (rows.length === 0) return null;
+  return pacientesMapper.toDTO(rows[0]);
+};

--- a/tp-final-integrador/src/database/pacientes.mapper.js
+++ b/tp-final-integrador/src/database/pacientes.mapper.js
@@ -1,0 +1,30 @@
+/**
+ * Mapper para el módulo de Pacientes.
+ * Convierte registros de la base de datos (snake_case) a objetos de transferencia de datos (DTO) en camelCase.
+ */
+
+/**
+ * Mapea una fila de la base de datos a un DTO de Paciente.
+ * @param {Object} row - Fila de la base de datos.
+ * @returns {Object} DTO en camelCase.
+ */
+export const toDTO = (row) => {
+  if (!row) return null;
+
+  return {
+    idPaciente: row.id_paciente,
+    idUsuario: row.id_usuario,
+    idObraSocial: row.id_obra_social,
+    activo: !!row.activo,
+  };
+};
+
+/**
+ * Mapea una lista de filas de la base de datos a una lista de DTOs.
+ * @param {Array} rows - Lista de filas.
+ * @returns {Array} Lista de DTOs.
+ */
+export const toDTOList = (rows) => {
+  if (!rows || !Array.isArray(rows)) return [];
+  return rows.map(toDTO);
+};

--- a/tp-final-integrador/src/database/turnos.js
+++ b/tp-final-integrador/src/database/turnos.js
@@ -1,4 +1,5 @@
 import { pool } from '../config/db.js';
+import { DB_STATUS } from '../constants/common.constants.js';
 
 /**
  * Registra un nuevo turno.
@@ -10,7 +11,7 @@ export const create = async (data) => {
 
   const query = `
     INSERT INTO turnos_reservas (id_medico, id_paciente, id_obra_social, fecha_hora, valor_total, atendido, activo)
-    VALUES (?, ?, ?, ?, ?, 0, 1)
+    VALUES (?, ?, ?, ?, ?, 0, ?)
   `;
 
   const [result] = await pool.execute(query, [
@@ -19,6 +20,7 @@ export const create = async (data) => {
     idObraSocial,
     fechaHora,
     valorTotal,
+    DB_STATUS.ACTIVE,
   ]);
 
   return result.insertId;
@@ -33,9 +35,9 @@ export const create = async (data) => {
 export const checkPatientOverlap = async (idPaciente, fechaHora) => {
   const query = `
     SELECT 1 FROM turnos_reservas
-    WHERE id_paciente = ? AND fecha_hora = ? AND activo = 1
+    WHERE id_paciente = ? AND fecha_hora = ? AND activo = ?
   `;
-  const [rows] = await pool.execute(query, [idPaciente, fechaHora]);
+  const [rows] = await pool.execute(query, [idPaciente, fechaHora, DB_STATUS.ACTIVE]);
   return rows.length > 0;
 };
 
@@ -48,8 +50,8 @@ export const checkPatientOverlap = async (idPaciente, fechaHora) => {
 export const existsByMedicoAndFechaHora = async (idMedico, fechaHora) => {
   const query = `
     SELECT 1 FROM turnos_reservas
-    WHERE id_medico = ? AND fecha_hora = ? AND activo = 1
+    WHERE id_medico = ? AND fecha_hora = ? AND activo = ?
   `;
-  const [rows] = await pool.execute(query, [idMedico, fechaHora]);
+  const [rows] = await pool.execute(query, [idMedico, fechaHora, DB_STATUS.ACTIVE]);
   return rows.length > 0;
 };

--- a/tp-final-integrador/src/database/turnos.js
+++ b/tp-final-integrador/src/database/turnos.js
@@ -1,0 +1,55 @@
+import { pool } from '../config/db.js';
+
+/**
+ * Registra un nuevo turno.
+ * @param {Object} data
+ * @returns {Promise<number>} ID del turno creado.
+ */
+export const create = async (data) => {
+  const { idMedico, idPaciente, idObraSocial, fechaHora, valorTotal } = data;
+
+  const query = `
+    INSERT INTO turnos_reservas (id_medico, id_paciente, id_obra_social, fecha_hora, valor_total, atendido, activo)
+    VALUES (?, ?, ?, ?, ?, 0, 1)
+  `;
+
+  const [result] = await pool.execute(query, [
+    idMedico,
+    idPaciente,
+    idObraSocial,
+    fechaHora,
+    valorTotal,
+  ]);
+
+  return result.insertId;
+};
+
+/**
+ * Verifica si un paciente ya tiene un turno reservado en una fecha y hora específicas de forma activa.
+ * @param {number} idPaciente
+ * @param {string} fechaHora
+ * @returns {Promise<boolean>}
+ */
+export const checkPatientOverlap = async (idPaciente, fechaHora) => {
+  const query = `
+    SELECT 1 FROM turnos_reservas
+    WHERE id_paciente = ? AND fecha_hora = ? AND activo = 1
+  `;
+  const [rows] = await pool.execute(query, [idPaciente, fechaHora]);
+  return rows.length > 0;
+};
+
+/**
+ * Verifica si un médico ya tiene un turno reservado en una fecha y hora específicas de forma activa.
+ * @param {number} idMedico
+ * @param {string} fechaHora
+ * @returns {Promise<boolean>}
+ */
+export const existsByMedicoAndFechaHora = async (idMedico, fechaHora) => {
+  const query = `
+    SELECT 1 FROM turnos_reservas
+    WHERE id_medico = ? AND fecha_hora = ? AND activo = 1
+  `;
+  const [rows] = await pool.execute(query, [idMedico, fechaHora]);
+  return rows.length > 0;
+};

--- a/tp-final-integrador/src/database/usuarios.js
+++ b/tp-final-integrador/src/database/usuarios.js
@@ -1,4 +1,5 @@
 import { pool } from '../config/db.js';
+import { DB_STATUS } from '../constants/common.constants.js';
 
 /**
  * Busca un usuario por su email.
@@ -7,8 +8,8 @@ import { pool } from '../config/db.js';
  */
 export const findByEmail = async (email) => {
   const [rows] = await pool.execute(
-    'SELECT id_usuario, documento, apellido, nombres, email, contrasenia, rol FROM usuarios WHERE email = ? AND activo = 1',
-    [email],
+    'SELECT id_usuario, documento, apellido, nombres, email, contrasenia, rol FROM usuarios WHERE email = ? AND activo = ?',
+    [email, DB_STATUS.ACTIVE],
   );
 
   if (rows.length === 0) return null;
@@ -22,8 +23,8 @@ export const findByEmail = async (email) => {
  */
 export const findById = async (id) => {
   const [rows] = await pool.execute(
-    'SELECT id_usuario, documento, apellido, nombres, email, rol FROM usuarios WHERE id_usuario = ? AND activo = 1',
-    [id],
+    'SELECT id_usuario, documento, apellido, nombres, email, rol FROM usuarios WHERE id_usuario = ? AND activo = ?',
+    [id, DB_STATUS.ACTIVE],
   );
 
   if (rows.length === 0) return null;

--- a/tp-final-integrador/src/routes/turnos.routes.js
+++ b/tp-final-integrador/src/routes/turnos.routes.js
@@ -1,0 +1,24 @@
+import { Router } from 'express';
+import * as turnosController from '../controllers/turnos.controller.js';
+import * as turnosValidator from '../validators/turnos.validator.js';
+import { ROLES } from '../constants/roles.constants.js';
+import { verifyToken, requireRole } from '../middlewares/auth.middleware.js';
+import { validateRequest } from '../middlewares/validate.middleware.js';
+import { methodNotAllowedHandler } from '../middlewares/method-not-allowed.middleware.js';
+
+const turnosRouter = Router();
+
+/**
+ * Rutas para el módulo de Turnos.
+ * Solo el Administrador (Role 3) puede registrar turnos.
+ */
+
+turnosRouter.use(verifyToken);
+turnosRouter.use(requireRole([ROLES.ADMIN]));
+
+turnosRouter
+  .route('/')
+  .post(turnosValidator.validateRegistrarTurno, validateRequest, turnosController.registrarTurno)
+  .all(methodNotAllowedHandler(['POST']));
+
+export default turnosRouter;

--- a/tp-final-integrador/src/routes/v1/index.js
+++ b/tp-final-integrador/src/routes/v1/index.js
@@ -4,6 +4,7 @@ import { ROUTES } from '../../constants/routes.constants.js';
 import healthRoutes from '../health.routes.js';
 import authRoutes from '../auth.routes.js';
 import obrasSocialesRouter from '../obras_sociales.routes.js';
+import turnosRouter from '../turnos.routes.js';
 
 const v1Router = Router();
 
@@ -14,5 +15,6 @@ const v1Router = Router();
 v1Router.use(ROUTES.HEALTH, healthRoutes);
 v1Router.use(ROUTES.AUTH, authRoutes);
 v1Router.use(ROUTES.OBRAS_SOCIALES, obrasSocialesRouter);
+v1Router.use(ROUTES.TURNOS, turnosRouter);
 
 export default v1Router;

--- a/tp-final-integrador/src/services/obras_sociales.service.js
+++ b/tp-final-integrador/src/services/obras_sociales.service.js
@@ -1,5 +1,6 @@
 import * as obrasSocialesModel from '../database/obras_sociales.js';
 import { AppError, ERROR_CODES } from '../helpers/errors.helper.js';
+import { DB_STATUS } from '../constants/common.constants.js';
 
 /**
  * Lógica de negocio para obras sociales.
@@ -14,7 +15,7 @@ export const createObraSocial = async (data) => {
   const existing = await obrasSocialesModel.findByName(data.nombre);
   if (existing) {
     const message =
-      existing.activo === 0
+      existing.activo === DB_STATUS.INACTIVE
         ? `Ya existe la obra social '${data.nombre}' pero se encuentra inactiva. Debería reactivarla.`
         : 'Ya existe una obra social con ese nombre';
     throw new AppError(ERROR_CODES.DUPLICATE_ENTRY, message);
@@ -41,7 +42,7 @@ export const updateObraSocial = async (id, data) => {
     const existing = await obrasSocialesModel.findByName(data.nombre);
     if (existing) {
       const message =
-        existing.activo === 0
+        existing.activo === DB_STATUS.INACTIVE
           ? `Ya existe la obra social '${data.nombre}' pero se encuentra inactiva. No puede usar este nombre.`
           : 'Ya existe otra obra social con ese nombre';
       throw new AppError(ERROR_CODES.DUPLICATE_ENTRY, message);

--- a/tp-final-integrador/src/services/turnos.service.js
+++ b/tp-final-integrador/src/services/turnos.service.js
@@ -1,0 +1,105 @@
+import * as turnosModel from '../database/turnos.js';
+import * as medicosModel from '../database/medicos.js';
+import * as pacientesModel from '../database/pacientes.js';
+import * as obrasSocialesModel from '../database/obras_sociales.js';
+import { AppError, ERROR_CODES } from '../helpers/errors.helper.js';
+
+/**
+ * Registra un nuevo turno con cálculo de valor_total.
+ * @param {Object} data - Datos del turno (idMedico, idPaciente, idObraSocial, fecha, hora).
+ * @returns {Promise<Object>} Datos del turno creado.
+ */
+export const registrarTurno = async (data) => {
+  const { idMedico, idPaciente, idObraSocial, fecha, hora } = data;
+
+  const medico = await medicosModel.findById(idMedico);
+  if (!medico) {
+    throw new AppError(ERROR_CODES.NOT_FOUND, 'El médico solicitado no existe');
+  }
+  if (!medico.activo) {
+    throw new AppError(ERROR_CODES.VALIDATION_ERROR, 'El médico solicitado no se encuentra activo');
+  }
+
+  const paciente = await pacientesModel.findById(idPaciente);
+  if (!paciente) {
+    throw new AppError(ERROR_CODES.NOT_FOUND, 'El paciente solicitado no existe');
+  }
+  if (!paciente.activo) {
+    throw new AppError(
+      ERROR_CODES.VALIDATION_ERROR,
+      'El paciente solicitado no se encuentra activo',
+    );
+  }
+
+  if (paciente.idObraSocial !== idObraSocial) {
+    throw new AppError(
+      ERROR_CODES.VALIDATION_ERROR,
+      'La obra social del turno no coincide con la del paciente',
+    );
+  }
+
+  const obraSocial = await obrasSocialesModel.findById(idObraSocial, false);
+  if (!obraSocial) {
+    throw new AppError(ERROR_CODES.NOT_FOUND, 'La obra social solicitada no existe');
+  }
+  if (!obraSocial.activo) {
+    throw new AppError(
+      ERROR_CODES.VALIDATION_ERROR,
+      'La obra social solicitada no se encuentra activa',
+    );
+  }
+
+  if (!obraSocial.esParticular) {
+    const aceptaObraSocial = await medicosModel.acceptsObraSocial(idMedico, idObraSocial);
+    if (!aceptaObraSocial) {
+      throw new AppError(
+        ERROR_CODES.VALIDATION_ERROR,
+        'El médico solicitado no trabaja con la obra social especificada',
+      );
+    }
+  }
+
+  let valorTotal = Number(medico.valorConsulta);
+
+  if (!obraSocial.esParticular) {
+    const descuento = valorTotal * Number(obraSocial.porcentajeDescuento);
+    valorTotal = valorTotal - descuento;
+  }
+
+  const fechaHora = `${fecha} ${hora}`;
+
+  const medicoTieneTurno = await turnosModel.existsByMedicoAndFechaHora(idMedico, fechaHora);
+  if (medicoTieneTurno) {
+    throw new AppError(
+      ERROR_CODES.VALIDATION_ERROR,
+      'El médico ya tiene un turno reservado para la misma fecha y hora',
+    );
+  }
+
+  const pacienteTieneTurno = await turnosModel.checkPatientOverlap(idPaciente, fechaHora);
+  if (pacienteTieneTurno) {
+    throw new AppError(
+      ERROR_CODES.VALIDATION_ERROR,
+      'El paciente ya tiene un turno reservado para la misma fecha y hora',
+    );
+  }
+
+  const idTurno = await turnosModel.create({
+    idMedico,
+    idPaciente,
+    idObraSocial,
+    fechaHora,
+    valorTotal,
+  });
+
+  return {
+    idTurno,
+    idMedico,
+    idPaciente,
+    idObraSocial,
+    fechaHora,
+    valorTotal,
+    atendido: 0,
+    activo: 1,
+  };
+};

--- a/tp-final-integrador/src/services/turnos.service.js
+++ b/tp-final-integrador/src/services/turnos.service.js
@@ -3,6 +3,7 @@ import * as medicosModel from '../database/medicos.js';
 import * as pacientesModel from '../database/pacientes.js';
 import * as obrasSocialesModel from '../database/obras_sociales.js';
 import { AppError, ERROR_CODES } from '../helpers/errors.helper.js';
+import { DB_STATUS } from '../constants/common.constants.js';
 
 /**
  * Registra un nuevo turno con cálculo de valor_total.
@@ -100,6 +101,6 @@ export const registrarTurno = async (data) => {
     fechaHora,
     valorTotal,
     atendido: 0,
-    activo: 1,
+    activo: DB_STATUS.ACTIVE,
   };
 };

--- a/tp-final-integrador/src/validators/turnos.validator.js
+++ b/tp-final-integrador/src/validators/turnos.validator.js
@@ -1,0 +1,49 @@
+import { body } from 'express-validator';
+
+/**
+ * Validaciones para el módulo de Turnos
+ */
+
+export const validateRegistrarTurno = [
+  body('idMedico')
+    .notEmpty()
+    .withMessage('El ID del médico es requerido')
+    .isInt({ min: 1 })
+    .withMessage('El ID del médico debe ser un número entero positivo')
+    .toInt(),
+
+  body('idPaciente')
+    .notEmpty()
+    .withMessage('El ID del paciente es requerido')
+    .isInt({ min: 1 })
+    .withMessage('El ID del paciente debe ser un número entero positivo')
+    .toInt(),
+
+  body('idObraSocial')
+    .notEmpty()
+    .withMessage('El ID de la obra social es requerido')
+    .isInt({ min: 1 })
+    .withMessage('El ID de la obra social debe ser un número entero positivo')
+    .toInt(),
+
+  body('fecha')
+    .notEmpty()
+    .withMessage('La fecha es requerida')
+    .isDate()
+    .withMessage('La fecha debe tener un formato válido (YYYY-MM-DD)')
+    .custom((value) => {
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const inputDate = new Date(value);
+      if (inputDate < today) {
+        throw new Error('La fecha no puede ser en el pasado');
+      }
+      return true;
+    }),
+
+  body('hora')
+    .notEmpty()
+    .withMessage('La hora es requerida')
+    .matches(/^([01]\d|2[0-3]):([0-5]\d)$/)
+    .withMessage('La hora debe tener un formato válido (HH:mm)'),
+];

--- a/tp-final-integrador/tests/modules/turnos.service.test.js
+++ b/tp-final-integrador/tests/modules/turnos.service.test.js
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as turnosService from '../../src/services/turnos.service.js';
+import * as turnosModel from '../../src/database/turnos.js';
+import * as medicosModel from '../../src/database/medicos.js';
+import * as pacientesModel from '../../src/database/pacientes.js';
+import * as obrasSocialesModel from '../../src/database/obras_sociales.js';
+
+vi.mock('../../src/database/turnos.js', () => ({
+  create: vi.fn(),
+  checkPatientOverlap: vi.fn(),
+  existsByMedicoAndFechaHora: vi.fn(),
+}));
+
+vi.mock('../../src/database/medicos.js', () => ({
+  findById: vi.fn(),
+  acceptsObraSocial: vi.fn(),
+}));
+
+vi.mock('../../src/database/pacientes.js', () => ({
+  findById: vi.fn(),
+}));
+
+vi.mock('../../src/database/obras_sociales.js', () => ({
+  findById: vi.fn(),
+}));
+
+describe('Turnos Service - Unit Tests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    medicosModel.acceptsObraSocial.mockResolvedValue(true);
+    turnosModel.checkPatientOverlap.mockResolvedValue(false);
+    turnosModel.existsByMedicoAndFechaHora.mockResolvedValue(false);
+  });
+
+  describe('registrarTurno() - Calculation Logic', () => {
+    it('debería calcular el valorTotal correctamente para una obra social con descuento (esParticular = false)', async () => {
+      const data = {
+        idMedico: 1,
+        idPaciente: 1,
+        idObraSocial: 1,
+        fecha: '2026-07-15',
+        hora: '14:30',
+      };
+
+      const mockMedico = { idMedico: 1, valorConsulta: 5000, activo: true };
+      const mockPaciente = { idPaciente: 1, idObraSocial: 1, activo: true };
+      const mockObraSocial = { id: 1, porcentajeDescuento: 0.1, esParticular: false, activo: true };
+
+      medicosModel.findById.mockResolvedValue(mockMedico);
+      pacientesModel.findById.mockResolvedValue(mockPaciente);
+      obrasSocialesModel.findById.mockResolvedValue(mockObraSocial);
+      turnosModel.create.mockResolvedValue(100);
+
+      const result = await turnosService.registrarTurno(data);
+
+      expect(turnosModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          valorTotal: 4500, // 5000 - (10% of 5000)
+        }),
+      );
+      expect(result).toEqual(
+        expect.objectContaining({
+          idTurno: 100,
+          valorTotal: 4500,
+        }),
+      );
+    });
+
+    it('debería calcular el valorTotal correctamente para atención particular (esParticular = true)', async () => {
+      const data = {
+        idMedico: 1,
+        idPaciente: 1,
+        idObraSocial: 2,
+        fecha: '2026-07-15',
+        hora: '14:30',
+      };
+
+      const mockMedico = { idMedico: 1, valorConsulta: 5000, activo: true };
+      const mockPaciente = { idPaciente: 1, idObraSocial: 2, activo: true };
+      const mockObraSocial = { id: 2, porcentajeDescuento: 0.1, esParticular: true, activo: true };
+
+      medicosModel.findById.mockResolvedValue(mockMedico);
+      pacientesModel.findById.mockResolvedValue(mockPaciente);
+      obrasSocialesModel.findById.mockResolvedValue(mockObraSocial);
+      turnosModel.create.mockResolvedValue(101);
+
+      const result = await turnosService.registrarTurno(data);
+
+      expect(turnosModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          valorTotal: 5000, // Particular, no discount
+        }),
+      );
+      expect(result).toEqual(
+        expect.objectContaining({
+          idTurno: 101,
+          valorTotal: 5000,
+        }),
+      );
+    });
+  });
+
+  describe('registrarTurno() - Validations', () => {
+    it('debería lanzar error si el médico no existe', async () => {
+      medicosModel.findById.mockResolvedValue(null);
+
+      await expect(turnosService.registrarTurno({ idMedico: 999 })).rejects.toThrow(
+        'El médico solicitado no existe',
+      );
+    });
+
+    it('debería lanzar error si el médico no está activo', async () => {
+      medicosModel.findById.mockResolvedValue({ idMedico: 1, activo: false });
+
+      await expect(turnosService.registrarTurno({ idMedico: 1 })).rejects.toMatchObject({
+        status: 422,
+        code: 'VALIDATION_ERROR',
+        message: 'El médico solicitado no se encuentra activo',
+      });
+    });
+
+    it('debería lanzar error si el paciente no existe', async () => {
+      medicosModel.findById.mockResolvedValue({ idMedico: 1, activo: true });
+      pacientesModel.findById.mockResolvedValue(null);
+
+      await expect(turnosService.registrarTurno({ idMedico: 1, idPaciente: 999 })).rejects.toThrow(
+        'El paciente solicitado no existe',
+      );
+    });
+
+    it('debería lanzar error si la obra social no existe', async () => {
+      medicosModel.findById.mockResolvedValue({ idMedico: 1, activo: true });
+      pacientesModel.findById.mockResolvedValue({ idPaciente: 1, idObraSocial: 999, activo: true });
+      obrasSocialesModel.findById.mockResolvedValue(null);
+
+      await expect(
+        turnosService.registrarTurno({ idMedico: 1, idPaciente: 1, idObraSocial: 999 }),
+      ).rejects.toThrow('La obra social solicitada no existe');
+    });
+
+    it('debería lanzar error si la obra social no está activa', async () => {
+      medicosModel.findById.mockResolvedValue({ idMedico: 1, activo: true });
+      pacientesModel.findById.mockResolvedValue({ idPaciente: 1, idObraSocial: 1, activo: true });
+      obrasSocialesModel.findById.mockResolvedValue({ id: 1, activo: false });
+
+      await expect(
+        turnosService.registrarTurno({ idMedico: 1, idPaciente: 1, idObraSocial: 1 }),
+      ).rejects.toMatchObject({
+        status: 422,
+        code: 'VALIDATION_ERROR',
+        message: 'La obra social solicitada no se encuentra activa',
+      });
+    });
+
+    it('debería lanzar error si el médico no trabaja con la obra social especificada', async () => {
+      medicosModel.findById.mockResolvedValue({ idMedico: 1, activo: true });
+      pacientesModel.findById.mockResolvedValue({ idPaciente: 1, idObraSocial: 1, activo: true });
+      obrasSocialesModel.findById.mockResolvedValue({ id: 1, activo: true, esParticular: false });
+      medicosModel.acceptsObraSocial.mockResolvedValue(false);
+
+      await expect(
+        turnosService.registrarTurno({ idMedico: 1, idPaciente: 1, idObraSocial: 1 }),
+      ).rejects.toMatchObject({
+        status: 422,
+        code: 'VALIDATION_ERROR',
+        message: 'El médico solicitado no trabaja con la obra social especificada',
+      });
+    });
+
+    it('debería permitir registrar el turno si el médico trabaja con la obra social', async () => {
+      const data = {
+        idMedico: 1,
+        idPaciente: 1,
+        idObraSocial: 1,
+        fecha: '2026-07-15',
+        hora: '14:30',
+      };
+      medicosModel.findById.mockResolvedValue({ idMedico: 1, valorConsulta: 5000, activo: true });
+      pacientesModel.findById.mockResolvedValue({ idPaciente: 1, idObraSocial: 1, activo: true });
+      obrasSocialesModel.findById.mockResolvedValue({
+        id: 1,
+        porcentajeDescuento: 0.1,
+        esParticular: false,
+        activo: true,
+      });
+      medicosModel.acceptsObraSocial.mockResolvedValue(true);
+      turnosModel.create.mockResolvedValue(100);
+
+      const result = await turnosService.registrarTurno(data);
+
+      expect(medicosModel.acceptsObraSocial).toHaveBeenCalledWith(1, 1);
+      expect(result.idTurno).toBe(100);
+    });
+
+    it('debería omitir la validación de medicos_obras_sociales si la obra social es particular', async () => {
+      const data = {
+        idMedico: 1,
+        idPaciente: 1,
+        idObraSocial: 1,
+        fecha: '2026-07-15',
+        hora: '14:30',
+      };
+      medicosModel.findById.mockResolvedValue({ idMedico: 1, valorConsulta: 5000, activo: true });
+      pacientesModel.findById.mockResolvedValue({ idPaciente: 1, idObraSocial: 1, activo: true });
+      obrasSocialesModel.findById.mockResolvedValue({
+        id: 1,
+        porcentajeDescuento: 0,
+        esParticular: true,
+        activo: true,
+      });
+      turnosModel.create.mockResolvedValue(100);
+
+      const result = await turnosService.registrarTurno(data);
+
+      expect(medicosModel.acceptsObraSocial).not.toHaveBeenCalled();
+      expect(result.idTurno).toBe(100);
+    });
+
+    it('debería lanzar error si el paciente ya tiene un turno reservado para la misma fecha y hora', async () => {
+      const data = {
+        idMedico: 1,
+        idPaciente: 1,
+        idObraSocial: 1,
+        fecha: '2026-07-15',
+        hora: '14:30',
+      };
+      medicosModel.findById.mockResolvedValue({ idMedico: 1, activo: true });
+      pacientesModel.findById.mockResolvedValue({ idPaciente: 1, idObraSocial: 1, activo: true });
+      obrasSocialesModel.findById.mockResolvedValue({ id: 1, activo: true, esParticular: false });
+      turnosModel.checkPatientOverlap.mockResolvedValue(true);
+
+      await expect(turnosService.registrarTurno(data)).rejects.toThrow(
+        'El paciente ya tiene un turno reservado para la misma fecha y hora',
+      );
+    });
+  });
+});

--- a/tp-final-integrador/tests/modules/turnos.service.test.js
+++ b/tp-final-integrador/tests/modules/turnos.service.test.js
@@ -128,6 +128,32 @@ describe('Turnos Service - Unit Tests', () => {
       );
     });
 
+    it('debería lanzar error si el paciente no está activo', async () => {
+      medicosModel.findById.mockResolvedValue({ idMedico: 1, activo: true });
+      pacientesModel.findById.mockResolvedValue({ idPaciente: 1, idObraSocial: 1, activo: false });
+
+      await expect(
+        turnosService.registrarTurno({ idMedico: 1, idPaciente: 1, idObraSocial: 1 }),
+      ).rejects.toMatchObject({
+        status: 422,
+        code: 'VALIDATION_ERROR',
+        message: 'El paciente solicitado no se encuentra activo',
+      });
+    });
+
+    it('debería lanzar error si la obra social del turno no coincide con la del paciente', async () => {
+      medicosModel.findById.mockResolvedValue({ idMedico: 1, activo: true });
+      pacientesModel.findById.mockResolvedValue({ idPaciente: 1, idObraSocial: 1, activo: true });
+
+      await expect(
+        turnosService.registrarTurno({ idMedico: 1, idPaciente: 1, idObraSocial: 2 }),
+      ).rejects.toMatchObject({
+        status: 422,
+        code: 'VALIDATION_ERROR',
+        message: 'La obra social del turno no coincide con la del paciente',
+      });
+    });
+
     it('debería lanzar error si la obra social no existe', async () => {
       medicosModel.findById.mockResolvedValue({ idMedico: 1, activo: true });
       pacientesModel.findById.mockResolvedValue({ idPaciente: 1, idObraSocial: 999, activo: true });
@@ -214,6 +240,26 @@ describe('Turnos Service - Unit Tests', () => {
 
       expect(medicosModel.acceptsObraSocial).not.toHaveBeenCalled();
       expect(result.idTurno).toBe(100);
+    });
+
+    it('debería lanzar error si el médico ya tiene un turno reservado para la misma fecha y hora', async () => {
+      const data = {
+        idMedico: 1,
+        idPaciente: 1,
+        idObraSocial: 1,
+        fecha: '2026-07-15',
+        hora: '14:30',
+      };
+      medicosModel.findById.mockResolvedValue({ idMedico: 1, activo: true });
+      pacientesModel.findById.mockResolvedValue({ idPaciente: 1, idObraSocial: 1, activo: true });
+      obrasSocialesModel.findById.mockResolvedValue({ id: 1, activo: true, esParticular: false });
+      turnosModel.existsByMedicoAndFechaHora.mockResolvedValue(true);
+
+      await expect(turnosService.registrarTurno(data)).rejects.toMatchObject({
+        status: 422,
+        code: 'VALIDATION_ERROR',
+        message: 'El médico ya tiene un turno reservado para la misma fecha y hora',
+      });
     });
 
     it('debería lanzar error si el paciente ya tiene un turno reservado para la misma fecha y hora', async () => {

--- a/tp-final-integrador/tests/modules/turnos.test.js
+++ b/tp-final-integrador/tests/modules/turnos.test.js
@@ -1,0 +1,343 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { app } from '../../src/app.js';
+import { pool } from '../../src/config/db.js';
+import { setupTestDB } from '../setup/db.js';
+import { ROLES } from '../../src/constants/roles.constants.js';
+
+describe('Turnos - Integration Tests', () => {
+  let adminToken;
+  let patientToken;
+  const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+
+  beforeEach(async () => {
+    await setupTestDB();
+
+    // Insertar datos necesarios para las pruebas
+    // 1. Especialidad
+    await pool.execute(
+      'INSERT INTO especialidades (id_especialidad, nombre, activo) VALUES (?, ?, ?)',
+      [1, 'PEDIATRÍA', 1],
+    );
+
+    // 2. Obra Social
+    await pool.execute(
+      'INSERT INTO obras_sociales (id_obra_social, nombre, descripcion, porcentaje_descuento, es_particular, activo) VALUES (?, ?, ?, ?, ?, ?)',
+      [1, 'OSDE', 'Plan 210', 0.1, 0, 1],
+    );
+    await pool.execute(
+      'INSERT INTO obras_sociales (id_obra_social, nombre, descripcion, porcentaje_descuento, es_particular, activo) VALUES (?, ?, ?, ?, ?, ?)',
+      [2, 'Particular', 'Sin obra social', 0.0, 1, 1],
+    );
+
+    // 2. Usuarios para Medico y Paciente
+    await pool.execute(
+      'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      [2, '22222222', 'Medico', 'Doc', 'medico@test.com', 'hash', '', ROLES.MEDICO, 1],
+    );
+    await pool.execute(
+      'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      [3, '33333333', 'Paciente', 'User', 'paciente@test.com', 'hash', '', ROLES.PACIENTE, 1],
+    );
+
+    // 3. Medico
+    await pool.execute(
+      'INSERT INTO medicos (id_medico, id_usuario, id_especialidad, matricula, valor_consulta) VALUES (?, ?, ?, ?, ?)',
+      [1, 2, 1, 2000, 5000.0],
+    );
+
+    // Relación Médico - Obra Social
+    await pool.execute(
+      'INSERT INTO medicos_obras_sociales (id_medico, id_obra_social, activo) VALUES (?, ?, ?)',
+      [1, 1, 1],
+    );
+
+    // 4. Paciente
+    await pool.execute(
+      'INSERT INTO pacientes (id_paciente, id_usuario, id_obra_social) VALUES (?, ?, ?)',
+      [1, 3, 1],
+    );
+
+    // Generar tokens
+    adminToken = jwt.sign({ id: 8, rol: ROLES.ADMIN, documento: '51000111' }, JWT_SECRET);
+    patientToken = jwt.sign({ id: 3, rol: ROLES.PACIENTE, documento: '33333333' }, JWT_SECRET);
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  describe('POST /api/v1/turnos', () => {
+    it('Scenario 1: Successful registration with health insurance (201)', async () => {
+      const payload = {
+        idMedico: 1,
+        idPaciente: 1,
+        idObraSocial: 1,
+        fecha: '2026-07-15',
+        hora: '14:30',
+      };
+
+      const response = await request(app)
+        .post('/api/v1/turnos')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(payload);
+
+      expect(response.status).toBe(201);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.valorTotal).toBe(4500.0); // 5000 - 10%
+    });
+
+    it('Scenario 2: Successful registration (201)', async () => {
+      const payload = {
+        idMedico: 1,
+        idPaciente: 1,
+        idObraSocial: 1,
+        fecha: '2026-07-16',
+        hora: '09:00',
+      };
+
+      const response = await request(app)
+        .post('/api/v1/turnos')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(payload);
+
+      expect(response.status).toBe(201);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.valorTotal).toBe(4500.0); // 5000 - 10%
+    });
+
+    it('Scenario 3: Access denied for non-admin user (403)', async () => {
+      const payload = {
+        idMedico: 1,
+        idPaciente: 1,
+        idObraSocial: 1,
+        fecha: '2026-07-15',
+        hora: '14:30',
+      };
+
+      const response = await request(app)
+        .post('/api/v1/turnos')
+        .set('Authorization', `Bearer ${patientToken}`)
+        .send(payload);
+
+      expect(response.status).toBe(403);
+    });
+
+    it('Scenario 4: Validation error - Invalid date (422)', async () => {
+      const payload = {
+        idMedico: 1,
+        idPaciente: 1,
+        idObraSocial: 1,
+        fecha: 'invalid-date',
+        hora: '14:30',
+      };
+
+      const response = await request(app)
+        .post('/api/v1/turnos')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(payload);
+
+      expect(response.status).toBe(422);
+      expect(response.body.success).toBe(false);
+    });
+
+    it('Scenario 5: Related entity not found (404)', async () => {
+      const payload = {
+        idMedico: 999, // No existe
+        idPaciente: 1,
+        idObraSocial: 1,
+        fecha: '2026-07-15',
+        hora: '14:30',
+      };
+
+      const response = await request(app)
+        .post('/api/v1/turnos')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(payload);
+
+      expect(response.status).toBe(404);
+    });
+
+    it('Scenario 6: Inactive physician (422)', async () => {
+      // Deactivate physician
+      await pool.execute('UPDATE usuarios SET activo = 0 WHERE id_usuario = 2');
+
+      const payload = {
+        idMedico: 1,
+        idPaciente: 1,
+        idObraSocial: 1,
+        fecha: '2026-07-15',
+        hora: '14:30',
+      };
+
+      const response = await request(app)
+        .post('/api/v1/turnos')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(payload);
+
+      expect(response.status).toBe(422);
+      expect(response.body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('Scenario 7: Inactive health insurance (422)', async () => {
+      // Deactivate health insurance
+      await pool.execute('UPDATE obras_sociales SET activo = 0 WHERE id_obra_social = 1');
+
+      const payload = {
+        idMedico: 1,
+        idPaciente: 1,
+        idObraSocial: 1,
+        fecha: '2026-07-15',
+        hora: '14:30',
+      };
+
+      const response = await request(app)
+        .post('/api/v1/turnos')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(payload);
+
+      expect(response.status).toBe(422);
+      expect(response.body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('Scenario 8: Physician not accepting insurance (422)', async () => {
+      // Deactivate relationship
+      await pool.execute(
+        'UPDATE medicos_obras_sociales SET activo = 0 WHERE id_medico = 1 AND id_obra_social = 1',
+      );
+
+      const payload = {
+        idMedico: 1,
+        idPaciente: 1,
+        idObraSocial: 1,
+        fecha: '2026-07-15',
+        hora: '14:30',
+      };
+
+      const response = await request(app)
+        .post('/api/v1/turnos')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(payload);
+
+      expect(response.status).toBe(422);
+      expect(response.body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('Scenario 9: Patient double booking (422)', async () => {
+      const payload = {
+        idMedico: 1,
+        idPaciente: 1,
+        idObraSocial: 1,
+        fecha: '2026-07-15',
+        hora: '14:30',
+      };
+
+      // Primer registro exitoso
+      const firstResponse = await request(app)
+        .post('/api/v1/turnos')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(payload);
+
+      expect(firstResponse.status).toBe(201);
+
+      // Segundo registro (solapamiento)
+      const secondResponse = await request(app)
+        .post('/api/v1/turnos')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(payload);
+
+      expect(secondResponse.status).toBe(422);
+      expect(secondResponse.body.error.code).toBe('VALIDATION_ERROR');
+      expect(secondResponse.body.error.message).toBe(
+        'El médico ya tiene un turno reservado para la misma fecha y hora',
+      );
+    });
+
+    it('Scenario X: Physician time conflict (422)', async () => {
+      // Necesitamos un segundo paciente para que no falle por solapamiento de paciente
+      await pool.execute(
+        'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        [4, '44444444', 'Paciente', 'Dos', 'paciente2@test.com', 'hash', '', 3, 1],
+      );
+      await pool.execute(
+        'INSERT INTO pacientes (id_paciente, id_usuario, id_obra_social) VALUES (?, ?, ?)',
+        [2, 4, 1],
+      );
+
+      // Primer turno con médico 1
+      const payload1 = {
+        idMedico: 1,
+        idPaciente: 1,
+        idObraSocial: 1,
+        fecha: '2026-07-15',
+        hora: '14:30',
+      };
+      const firstResponse = await request(app)
+        .post('/api/v1/turnos')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(payload1);
+
+      expect(firstResponse.status).toBe(201);
+
+      // Segundo turno: mismo médico, mismo horario, paciente distinto
+      const payload2 = {
+        idMedico: 1,
+        idPaciente: 2,
+        idObraSocial: 1,
+        fecha: '2026-07-15',
+        hora: '14:30',
+      };
+      const secondResponse = await request(app)
+        .post('/api/v1/turnos')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(payload2);
+
+      expect(secondResponse.status).toBe(422);
+      expect(secondResponse.body.error.code).toBe('VALIDATION_ERROR');
+      expect(secondResponse.body.error.message).toBe(
+        'El médico ya tiene un turno reservado para la misma fecha y hora',
+      );
+    });
+
+    it('Scenario Y: Health insurance mismatch with patient (422)', async () => {
+      // Paciente 1 tiene idObraSocial = 1 (OSDE); enviamos idObraSocial = 2 (Particular)
+      const payload = {
+        idMedico: 1,
+        idPaciente: 1,
+        idObraSocial: 2,
+        fecha: '2026-07-15',
+        hora: '14:30',
+      };
+
+      const response = await request(app)
+        .post('/api/v1/turnos')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(payload);
+
+      expect(response.status).toBe(422);
+      expect(response.body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('Scenario 10: Inactive patient (422)', async () => {
+      // Desactivar el paciente
+      await pool.execute('UPDATE usuarios SET activo = 0 WHERE id_usuario = 3');
+
+      const payload = {
+        idMedico: 1,
+        idPaciente: 1,
+        idObraSocial: 1,
+        fecha: '2026-07-15',
+        hora: '14:30',
+      };
+
+      const response = await request(app)
+        .post('/api/v1/turnos')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(payload);
+
+      expect(response.status).toBe(422);
+      expect(response.body.error.code).toBe('VALIDATION_ERROR');
+    });
+  });
+});

--- a/tp-final-integrador/tests/modules/turnos.test.js
+++ b/tp-final-integrador/tests/modules/turnos.test.js
@@ -142,6 +142,24 @@ describe('Turnos - Integration Tests', () => {
       expect(response.body.success).toBe(false);
     });
 
+    it('Scenario validation error: Invalid hour format (422)', async () => {
+      const payload = {
+        idMedico: 1,
+        idPaciente: 1,
+        idObraSocial: 1,
+        fecha: '2026-07-15',
+        hora: '25:99',
+      };
+
+      const response = await request(app)
+        .post('/api/v1/turnos')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send(payload);
+
+      expect(response.status).toBe(422);
+      expect(response.body.success).toBe(false);
+    });
+
     it('Scenario 5: Related entity not found (404)', async () => {
       const payload = {
         idMedico: 999, // No existe


### PR DESCRIPTION
## Resumen

Completa el módulo de **turnos** con  validaciones al registrar un turno, más todos los archivos necesarios del módulo (controller, service, database, routes, validators, tests, documentación y colección Bruno).

Este PR incluye 18 archivos: 15 nuevos y 3 modificados.

---

## Validaciones agregadas en `turnos.service.registrarTurno()`

| # | Validación | Código | Error |
|---|---|---|---|
| RF1 | Choque horario del médico | `existsByMedicoAndFechaHora(idMedico, fechaHora)` | `422 - El médico ya tiene un turno reservado...` |
| RF2 | OS del turno coincide con OS del paciente | `paciente.idObraSocial !== idObraSocial` | `422 - La obra social del turno no coincide...` |
| RF3 | Paciente activo | `!paciente.activo` | `422 - El paciente solicitado no se encuentra activo` |

## Archivos

### Nuevos (15)

| Archivo | Descripción |
|---------|-------------|
| `src/controllers/turnos.controller.js` | Controlador con `registrarTurno` |
| `src/services/turnos.service.js` | Service con lógica de negocio y validaciones (RF1, RF2, RF3) |
| `src/database/turnos.js` | Modelo con queries `create`, `checkPatientOverlap`, `existsByMedicoAndFechaHora` |
| `src/database/medicos.js` | Modelo con `findById` y `acceptsObraSocial` |
| `src/database/medicos.mapper.js` | Mapper snake_case → camelCase para médicos |
| `src/database/pacientes.js` | Modelo con `findById` (incluye JOIN con `usuarios.activo`) |
| `src/database/pacientes.mapper.js` | Mapper snake_case → camelCase para pacientes |
| `src/routes/turnos.routes.js` | Rutas: `POST /api/v1/turnos` con auth solo ADMIN |
| `src/validators/turnos.validator.js` | Validaciones con express-validator |
| `tests/modules/turnos.test.js` | Tests de integración: 10 escenarios |
| `tests/modules/turnos.service.test.js` | Tests unitarios del service con mocks |
| `bruno-collection/turnos/folder.bru` | Colección Bruno |
| `bruno-collection/turnos/registrar-obra-social.bru` | Request: turno con obra social |
| `bruno-collection/turnos/registrar-particular.bru` | Request: turno particular |
| `bruno-collection/turnos/error-fecha-pasada.bru` | Request: error fecha pasada |

### Modificados (3)

| Archivo | Cambio |
|---------|--------|
| `src/constants/routes.constants.js` | `+ TURNOS: '/turnos'` |
| `src/routes/v1/index.js` | `+ import y registro de turnosRouter` |
| `docs/ENDPOINTS.md` | `+ documentación POST /api/v1/turnos` |

## Testing

- 122 tests pasando (14 suites)
- Tests de integración con supertest + MySQL
- Tests unitarios con mocks (vitest)
- Validaciones cubiertas: médico inactivo, paciente inexistente/inactivo, OS inactiva, choque horario médico, solapamiento paciente, OS no aceptada, OS no coincide con paciente

---

## Issues Vinculados

- Closes #26
