### PR TITLE
feat(auth): migrar autenticación y autorización a passport.js

### DIFF
--- a/tp-final-integrador/bruno-collection/auth/folder.bru
+++ b/tp-final-integrador/bruno-collection/auth/folder.bru
@@ -1,0 +1,3 @@
+meta {
+  name: Autenticación
+}

--- a/tp-final-integrador/bruno-collection/auth/login.bru
+++ b/tp-final-integrador/bruno-collection/auth/login.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Login
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/auth/login
+  body: json
+  auth: none
+}
+
+headers {
+  Accept: application/json
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "email": "ferben@correo.com",
+    "contrasenia": "password123"
+  }
+}
+
+script:post-response {
+  if (res.body && res.body.success && res.body.data && res.body.data.token) {
+    bru.setVar("authToken", res.body.data.token);
+  }
+}
+
+docs {
+  Inicia sesión de un usuario con sus credenciales (email y contrasenia).
+  Retorna un JWT de acceso en la respuesta y guarda el token en la variable `authToken`.
+}
+​

--- a/tp-final-integrador/bruno-collection/obras-sociales/Get All (Actives and not actives).bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/Get All (Actives and not actives).bru
@@ -7,7 +7,12 @@ meta {
 get {
   url: {{baseUrl}}/obras-sociales?activo=all
   body: none
-  auth: inherit
+  auth: none
+}
+
+headers {
+  Accept: application/json
+  Authorization: Bearer {{authToken}}
 }
 
 params:query {

--- a/tp-final-integrador/bruno-collection/obras-sociales/Get All Actives.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/Get All Actives.bru
@@ -9,3 +9,8 @@ get {
   body: none
   auth: none
 }
+
+headers {
+  Accept: application/json
+  Authorization: Bearer {{authToken}}
+}

--- a/tp-final-integrador/package-lock.json
+++ b/tp-final-integrador/package-lock.json
@@ -17,7 +17,10 @@
         "jsonwebtoken": "9.0.3",
         "morgan": "1.10.1",
         "multer": "2.1.1",
-        "mysql2": "3.20.0"
+        "mysql2": "3.20.0",
+        "passport": "0.7.0",
+        "passport-jwt": "4.0.1",
+        "passport-local": "1.0.0"
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
@@ -3442,6 +3445,53 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/passport": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
+      "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1",
+        "utils-merge": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-jwt": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.1.tgz",
+      "integrity": "sha512-UCKMDYhNuGOBE9/9Ycuoyh7vP6jpeTp/+sfMJl7nLff/t6dps+iaeE0hhNkKN8/HZHcJ7lCdOyDxHdDoxoSvdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jsonwebtoken": "^9.0.0",
+        "passport-strategy": "^1.0.0"
+      }
+    },
+    "node_modules/passport-local": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
+      "integrity": "sha512-9wCE6qKznvf9mQYYbgJ3sVOHmCWoUNMVFoZzNoznmISbhnNNPhN9xfY3sLmScHMetEJeoY7CXwfhCe7argfQow==",
+      "dependencies": {
+        "passport-strategy": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3478,6 +3528,11 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4251,6 +4306,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/validator": {
       "version": "13.15.35",

--- a/tp-final-integrador/package.json
+++ b/tp-final-integrador/package.json
@@ -32,7 +32,10 @@
     "jsonwebtoken": "9.0.3",
     "morgan": "1.10.1",
     "multer": "2.1.1",
-    "mysql2": "3.20.0"
+    "mysql2": "3.20.0",
+    "passport": "0.7.0",
+    "passport-jwt": "4.0.1",
+    "passport-local": "1.0.0"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",

--- a/tp-final-integrador/src/app.js
+++ b/tp-final-integrador/src/app.js
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import morgan from 'morgan';
+import passport from './config/passport.js';
 import apiRouter from './routes/index.js';
 import { notFoundHandler, globalErrorHandler } from './middlewares/error.middleware.js';
 import validateContentType from './middlewares/content.middleware.js';
@@ -24,6 +25,7 @@ if (process.env.NODE_ENV !== 'test') {
 app.use(validateContentType);
 app.use(express.json());
 app.use(express.static('public'));
+app.use(passport.initialize());
 
 // Enrutamiento  (API)
 app.use(apiRouter);

--- a/tp-final-integrador/src/config/passport.js
+++ b/tp-final-integrador/src/config/passport.js
@@ -1,0 +1,58 @@
+import passport from 'passport';
+import { Strategy as LocalStrategy } from 'passport-local';
+import { Strategy as JwtStrategy, ExtractJwt } from 'passport-jwt';
+import * as authService from '../services/auth.service.js';
+import * as usuariosModel from '../database/usuarios.js';
+import { ERROR_CODES } from '../helpers/errors.helper.js';
+
+passport.use(
+  new LocalStrategy(
+    {
+      usernameField: 'email',
+      passwordField: 'contrasenia',
+      session: false,
+    },
+    async (email, password, done) => {
+      try {
+        const result = await authService.login(email, password);
+        return done(null, result);
+      } catch (error) {
+        if (
+          error.code === ERROR_CODES.UNAUTHORIZED.code ||
+          error.status === ERROR_CODES.UNAUTHORIZED.status
+        ) {
+          return done(null, false, { message: error.message || ERROR_CODES.UNAUTHORIZED.message });
+        }
+        return done(error);
+      }
+    },
+  ),
+);
+
+passport.use(
+  new JwtStrategy(
+    {
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      secretOrKey: process.env.JWT_SECRET || 'secret',
+    },
+    async (jwt_payload, done) => {
+      try {
+        if (!jwt_payload || !jwt_payload.id) {
+          return done(null, false);
+        }
+
+        // Validar que el usuario exista y esté activo
+        const user = await usuariosModel.findById(jwt_payload.id);
+        if (!user) {
+          return done(null, false);
+        }
+
+        return done(null, user);
+      } catch (error) {
+        return done(error);
+      }
+    },
+  ),
+);
+
+export default passport;

--- a/tp-final-integrador/src/controllers/auth.controller.js
+++ b/tp-final-integrador/src/controllers/auth.controller.js
@@ -1,5 +1,3 @@
-import { matchedData } from 'express-validator';
-import * as authService from '../services/auth.service.js';
 import { successResponse } from '../helpers/response.helper.js';
 
 /**
@@ -10,8 +8,7 @@ import { successResponse } from '../helpers/response.helper.js';
  * Maneja el inicio de sesión.
  */
 export const login = async (req, res) => {
-  const { email, password } = matchedData(req);
-  const result = await authService.login(email, password);
+  const { token } = req.user;
 
-  return successResponse(res, result);
+  return successResponse(res, { token });
 };

--- a/tp-final-integrador/src/database/usuarios.js
+++ b/tp-final-integrador/src/database/usuarios.js
@@ -1,18 +1,21 @@
 import { pool } from '../config/db.js';
+import { DB_STATUS } from '../constants/common.constants.js';
+import * as usuariosMapper from './usuarios.mapper.js';
 
 /**
- * Busca un usuario por su email.
+ * Busca un usuario por email y contraseña (la comparación SHA2-256 se realiza a nivel de base de datos).
  * @param {string} email
- * @returns {Promise<Object|null>}
+ * @param {string} password - Contraseña en texto plano; hasheada a nivel de base de datos.
+ * @returns {Promise<Object|null>} `{ id, rol, nombreCompleto }` o null si las credenciales son inválidas.
  */
-export const findByEmail = async (email) => {
+export const findByCredentials = async (email, password) => {
   const [rows] = await pool.execute(
-    'SELECT id_usuario, documento, apellido, nombres, email, contrasenia, rol FROM usuarios WHERE email = ? AND activo = 1',
-    [email],
+    "SELECT id_usuario, rol, CONCAT(apellido, ', ', nombres) AS nombre_completo FROM usuarios WHERE email = ? AND contrasenia = SHA2(?, 256) AND activo = ?",
+    [email, password, DB_STATUS.ACTIVE],
   );
 
   if (rows.length === 0) return null;
-  return rows[0];
+  return usuariosMapper.toDTO(rows[0]);
 };
 
 /**
@@ -27,5 +30,5 @@ export const findById = async (id) => {
   );
 
   if (rows.length === 0) return null;
-  return rows[0];
+  return usuariosMapper.toDTO(rows[0]);
 };

--- a/tp-final-integrador/src/database/usuarios.mapper.js
+++ b/tp-final-integrador/src/database/usuarios.mapper.js
@@ -1,0 +1,35 @@
+/**
+ * Mapper para el módulo de Usuarios.
+ * Convierte registros de la base de datos (snake_case) a objetos de transferencia de datos (DTO) en camelCase.
+ */
+
+/**
+ * Mapea una fila de la base de datos a un DTO de Usuario.
+ * @param {Object} row - Fila de la base de datos.
+ * @returns {Object} DTO en camelCase.
+ */
+export const toDTO = (row) => {
+  if (!row) return null;
+
+  const dto = {};
+
+  if (row.id_usuario !== undefined) dto.id = row.id_usuario;
+  if (row.documento !== undefined) dto.documento = row.documento;
+  if (row.apellido !== undefined) dto.apellido = row.apellido;
+  if (row.nombres !== undefined) dto.nombres = row.nombres;
+  if (row.email !== undefined) dto.email = row.email;
+  if (row.rol !== undefined) dto.rol = row.rol;
+  if (row.nombre_completo !== undefined) dto.nombreCompleto = row.nombre_completo;
+
+  return dto;
+};
+
+/**
+ * Mapea una lista de filas de la base de datos a una lista de DTOs.
+ * @param {Array} rows - Lista de filas.
+ * @returns {Array} Lista de DTOs.
+ */
+export const toDTOList = (rows) => {
+  if (!rows || !Array.isArray(rows)) return [];
+  return rows.map(toDTO);
+};

--- a/tp-final-integrador/src/middlewares/auth.middleware.js
+++ b/tp-final-integrador/src/middlewares/auth.middleware.js
@@ -1,34 +1,56 @@
-import jwt from 'jsonwebtoken';
+import passport from 'passport';
 import { errorResponse } from '../helpers/response.helper.js';
 import { ERROR_CODES } from '../helpers/errors.helper.js';
 
 /**
- * Middleware para verificar el token JWT
+ * Middleware para autenticar solicitudes mediante token JWT
  */
-export const verifyToken = async (req, res, next) => {
-  const authHeader = req.headers.authorization;
+export const authenticateJwt = async (req, res, next) => {
+  passport.authenticate('jwt', { session: false }, (err, user, info) => {
+    if (err) {
+      return errorResponse({
+        res,
+        errorType: ERROR_CODES.INTERNAL_ERROR,
+      });
+    }
 
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    return errorResponse({
-      res,
-      errorType: ERROR_CODES.UNAUTHORIZED,
-      message: 'No se proporcionó un token',
-    });
-  }
+    if (!user) {
+      let message = 'Token inválido o expirado';
+      if (info && info.message === 'No auth token') {
+        message = 'No se proporcionó un token';
+      } else if (info && (info.name === 'TokenExpiredError' || info.message === 'jwt expired')) {
+        message = 'Token expirado';
+      }
+      return errorResponse({
+        res,
+        errorType: ERROR_CODES.UNAUTHORIZED,
+        message,
+      });
+    }
 
-  const token = authHeader.split(' ')[1];
-
-  try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
-    req.user = decoded;
+    req.user = user;
     next();
-  } catch {
-    return errorResponse({
-      res,
-      errorType: ERROR_CODES.UNAUTHORIZED,
-      message: 'Token inválido o expirado',
-    });
-  }
+  })(req, res, next);
+};
+
+/**
+ * Middleware para autenticar credenciales locales (email/contraseña)
+ */
+export const authenticateLocal = (req, res, next) => {
+  passport.authenticate('local', { session: false }, (err, user, info) => {
+    if (err) {
+      return next(err);
+    }
+    if (!user) {
+      return errorResponse({
+        res,
+        errorType: ERROR_CODES.UNAUTHORIZED,
+        message: info?.message || ERROR_CODES.UNAUTHORIZED.message,
+      });
+    }
+    req.user = user;
+    next();
+  })(req, res, next);
 };
 
 /**

--- a/tp-final-integrador/src/routes/auth.routes.js
+++ b/tp-final-integrador/src/routes/auth.routes.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import * as authController from '../controllers/auth.controller.js';
 import { loginValidator } from '../validators/auth.validator.js';
 import { methodNotAllowedHandler } from '../middlewares/method-not-allowed.middleware.js';
+import { authenticateLocal } from '../middlewares/auth.middleware.js';
 
 const router = Router();
 
@@ -12,7 +13,7 @@ const router = Router();
 // POST /api/v1/auth/login
 router
   .route('/login')
-  .post(loginValidator, authController.login)
+  .post(loginValidator, authenticateLocal, authController.login)
   .all(methodNotAllowedHandler(['POST']));
 
 export default router;

--- a/tp-final-integrador/src/routes/obras_sociales.routes.js
+++ b/tp-final-integrador/src/routes/obras_sociales.routes.js
@@ -2,8 +2,8 @@ import { Router } from 'express';
 import * as obrasSocialesController from '../controllers/obras_sociales.controller.js';
 import * as obrasSocialesValidator from '../validators/obras_sociales.validator.js';
 import { validateListQuery } from '../middlewares/query.validator.js';
-// import { ROLES } from '../constants/roles.constants.js';
-// import { verifyToken, requireRole } from '../middlewares/auth.middleware.js';
+import { ROLES } from '../constants/roles.constants.js';
+import { authenticateJwt, requireRole } from '../middlewares/auth.middleware.js';
 import { validateRequest } from '../middlewares/validate.middleware.js';
 import { methodNotAllowedHandler } from '../middlewares/method-not-allowed.middleware.js';
 
@@ -15,8 +15,8 @@ const obrasSocialesRouter = Router();
  */
 
 // Middleware global para todas las rutas de este router
-// obrasSocialesRouter.use(verifyToken);
-// obrasSocialesRouter.use(requireRole([ROLES.ADMIN]));
+obrasSocialesRouter.use(authenticateJwt);
+obrasSocialesRouter.use(requireRole([ROLES.ADMIN]));
 
 obrasSocialesRouter
   .route('/')

--- a/tp-final-integrador/src/services/auth.service.js
+++ b/tp-final-integrador/src/services/auth.service.js
@@ -1,5 +1,4 @@
 import jwt from 'jsonwebtoken';
-import bcryptjs from 'bcryptjs';
 import * as usuariosModel from '../database/usuarios.js';
 import { AppError, ERROR_CODES } from '../helpers/errors.helper.js';
 
@@ -14,33 +13,26 @@ import { AppError, ERROR_CODES } from '../helpers/errors.helper.js';
  * @returns {Promise<Object>} Token y datos del usuario.
  */
 export const login = async (email, password) => {
-  const user = await usuariosModel.findByEmail(email);
+  const user = await usuariosModel.findByCredentials(email, password);
 
   if (!user) {
     throw new AppError(ERROR_CODES.UNAUTHORIZED, 'Credenciales inválidas');
   }
 
-  const isPasswordValid = await bcryptjs.compare(password, user.contrasenia);
-
-  if (!isPasswordValid) {
-    throw new AppError(ERROR_CODES.UNAUTHORIZED, 'Credenciales inválidas');
-  }
-
-  // Generar Token
   const payload = {
-    id: user.id_usuario,
+    id: user.id,
     rol: user.rol,
-    documento: user.documento,
   };
 
   const token = jwt.sign(payload, process.env.JWT_SECRET || 'secret', {
     expiresIn: process.env.JWT_EXPIRES_IN || '1h',
   });
-  // eslint-disable-next-line no-unused-vars
-  const { contrasenia: _, ...userWithoutPassword } = user;
 
   return {
     token,
-    user: userWithoutPassword,
+    user: {
+      ...user,
+      email,
+    },
   };
 };

--- a/tp-final-integrador/src/validators/auth.validator.js
+++ b/tp-final-integrador/src/validators/auth.validator.js
@@ -13,6 +13,6 @@ export const loginValidator = [
     .withMessage('Debe ser un email válido')
     .notEmpty()
     .withMessage('El email es requerido'),
-  body('password').notEmpty().withMessage('La contraseña es requerida'),
+  body('contrasenia').notEmpty().withMessage('La contraseña es requerida'),
   validateRequest,
 ];

--- a/tp-final-integrador/tests/config/passport.test.js
+++ b/tp-final-integrador/tests/config/passport.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import passport from '../../src/config/passport.js';
+import * as authService from '../../src/services/auth.service.js';
+import * as usuariosModel from '../../src/database/usuarios.js';
+import { ERROR_CODES, AppError } from '../../src/helpers/errors.helper.js';
+
+vi.mock('../../src/services/auth.service.js');
+vi.mock('../../src/database/usuarios.js');
+
+describe('Passport Config', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('LocalStrategy', () => {
+    it('debería registrar la estrategia local', () => {
+      expect(passport._strategies.local).toBeDefined();
+    });
+
+    it('debería llamar a authService.login y retornar done(null, result) con credenciales válidas', async () => {
+      const mockResult = { token: 'valid-token', user: { id: 1, email: 'test@example.com' } };
+      authService.login.mockResolvedValue(mockResult);
+
+      const localStrategy = passport._strategies.local;
+      const done = vi.fn();
+
+      await localStrategy._verify('test@example.com', 'password123', done);
+
+      expect(authService.login).toHaveBeenCalledWith('test@example.com', 'password123');
+      expect(done).toHaveBeenCalledWith(null, mockResult);
+    });
+
+    it('debería retornar done(null, false) si authService.login lanza error de credenciales', async () => {
+      const authError = new AppError(ERROR_CODES.UNAUTHORIZED, 'Credenciales inválidas');
+      authService.login.mockRejectedValue(authError);
+
+      const localStrategy = passport._strategies.local;
+      const done = vi.fn();
+
+      await localStrategy._verify('test@example.com', 'wrongpassword', done);
+
+      expect(authService.login).toHaveBeenCalledWith('test@example.com', 'wrongpassword');
+      expect(done).toHaveBeenCalledWith(null, false, expect.any(Object));
+    });
+
+    it('debería retornar done(err) si authService.login lanza un error inesperado de infraestructura', async () => {
+      const dbError = new Error('Database connection failed');
+      authService.login.mockRejectedValue(dbError);
+
+      const localStrategy = passport._strategies.local;
+      const done = vi.fn();
+
+      await localStrategy._verify('test@example.com', 'password123', done);
+
+      expect(authService.login).toHaveBeenCalledWith('test@example.com', 'password123');
+      expect(done).toHaveBeenCalledWith(dbError);
+    });
+  });
+
+  describe('JwtStrategy', () => {
+    it('debería registrar la estrategia jwt', () => {
+      expect(passport._strategies.jwt).toBeDefined();
+    });
+
+    it('debería retornar el usuario obtenido de la BD si el payload del JWT es válido', async () => {
+      const payload = { id: 1, rol: 3, documento: '12345678', iat: 123456, exp: 234567 };
+      const mockUser = { id: 1, rol: 3, email: 'test@example.com' };
+      usuariosModel.findById.mockResolvedValue(mockUser);
+
+      const jwtStrategy = passport._strategies.jwt;
+      const done = vi.fn();
+
+      await jwtStrategy._verify(payload, done);
+
+      expect(usuariosModel.findById).toHaveBeenCalledWith(payload.id);
+      expect(done).toHaveBeenCalledWith(null, mockUser);
+    });
+
+    it('debería retornar done(null, false) si el usuario no existe en la BD', async () => {
+      const payload = { id: 1, rol: 3 };
+      usuariosModel.findById.mockResolvedValue(null);
+
+      const jwtStrategy = passport._strategies.jwt;
+      const done = vi.fn();
+
+      await jwtStrategy._verify(payload, done);
+
+      expect(usuariosModel.findById).toHaveBeenCalledWith(payload.id);
+      expect(done).toHaveBeenCalledWith(null, false);
+    });
+
+    it('debería retornar done(err) si ocurre un error en la BD', async () => {
+      const payload = { id: 1, rol: 3 };
+      const dbError = new Error('DB Error');
+      usuariosModel.findById.mockRejectedValue(dbError);
+
+      const jwtStrategy = passport._strategies.jwt;
+      const done = vi.fn();
+
+      await jwtStrategy._verify(payload, done);
+
+      expect(done).toHaveBeenCalledWith(dbError);
+    });
+
+    it('debería retornar done(null, false) si el payload del JWT es falsy (token faltante)', async () => {
+      const jwtStrategy = passport._strategies.jwt;
+      const done = vi.fn();
+
+      await jwtStrategy._verify(null, done);
+
+      expect(done).toHaveBeenCalledWith(null, false);
+    });
+  });
+});

--- a/tp-final-integrador/tests/middlewares/auth.middleware.test.js
+++ b/tp-final-integrador/tests/middlewares/auth.middleware.test.js
@@ -1,10 +1,17 @@
 import { ROLES } from '../../src/constants/roles.constants.js';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import jwt from 'jsonwebtoken';
+import passport from 'passport';
+
+vi.mock('passport', () => {
+  return {
+    default: {
+      authenticate: vi.fn(),
+    },
+  };
+});
 
 describe('Auth Middleware', () => {
   let req, res, next;
-  const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 
   beforeEach(() => {
     req = { headers: {} };
@@ -24,14 +31,19 @@ describe('Auth Middleware', () => {
     vi.clearAllMocks();
   });
 
-  describe('verifyToken', () => {
+  describe('authenticateJwt', () => {
     it('debería permitir acceso con un token válido', async () => {
       const payload = { id: 1, rol: ROLES.ADMIN, documento: '12345678' };
-      const token = jwt.sign(payload, JWT_SECRET);
-      req.headers.authorization = `Bearer ${token}`;
+      passport.authenticate.mockImplementation((strategy, options, callback) => {
+        return (_req, _res, _next) => {
+          callback(null, payload, null);
+        };
+      });
 
-      const { verifyToken } = await import('../../src/middlewares/auth.middleware.js');
-      await verifyToken(req, res, next);
+      req.headers.authorization = 'Bearer valid-token';
+
+      const { authenticateJwt } = await import('../../src/middlewares/auth.middleware.js');
+      await authenticateJwt(req, res, next);
 
       expect(req.user).toBeDefined();
       expect(req.user.id).toBe(payload.id);
@@ -39,18 +51,30 @@ describe('Auth Middleware', () => {
     });
 
     it('debería retornar 401 si no hay token', async () => {
-      const { verifyToken } = await import('../../src/middlewares/auth.middleware.js');
-      await verifyToken(req, res, next);
+      passport.authenticate.mockImplementation((strategy, options, callback) => {
+        return (_req, _res, _next) => {
+          callback(null, false, { message: 'No auth token' });
+        };
+      });
+
+      const { authenticateJwt } = await import('../../src/middlewares/auth.middleware.js');
+      await authenticateJwt(req, res, next);
 
       expect(res.statusCode).toBe(401);
       expect(res.body.error.code).toBe('UNAUTHORIZED');
     });
 
     it('debería retornar 401 si el token es inválido', async () => {
+      passport.authenticate.mockImplementation((strategy, options, callback) => {
+        return (_req, _res, _next) => {
+          callback(null, false, { message: 'Token inválido o expirado' });
+        };
+      });
+
       req.headers.authorization = 'Bearer token-invalido';
 
-      const { verifyToken } = await import('../../src/middlewares/auth.middleware.js');
-      await verifyToken(req, res, next);
+      const { authenticateJwt } = await import('../../src/middlewares/auth.middleware.js');
+      await authenticateJwt(req, res, next);
 
       expect(res.statusCode).toBe(401);
       expect(res.body.error.code).toBe('UNAUTHORIZED');
@@ -77,6 +101,51 @@ describe('Auth Middleware', () => {
       await middleware(req, res, next);
 
       expect(next).toHaveBeenCalled();
+    });
+  });
+
+  describe('authenticateLocal', () => {
+    it('debería autenticar con credenciales válidas y setear req.user', async () => {
+      const mockUser = { id: 1, email: 'test@example.com' };
+      passport.authenticate.mockImplementation((_strategy, _options, callback) => {
+        return (_req, _res, _next) => {
+          callback(null, mockUser, null);
+        };
+      });
+
+      const { authenticateLocal } = await import('../../src/middlewares/auth.middleware.js');
+      await authenticateLocal(req, res, next);
+
+      expect(req.user).toBe(mockUser);
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('debería retornar 401 si las credenciales son inválidas', async () => {
+      passport.authenticate.mockImplementation((_strategy, _options, callback) => {
+        return (_req, _res, _next) => {
+          callback(null, false, { message: 'Credenciales inválidas' });
+        };
+      });
+
+      const { authenticateLocal } = await import('../../src/middlewares/auth.middleware.js');
+      await authenticateLocal(req, res, next);
+
+      expect(res.statusCode).toBe(401);
+      expect(res.body.error.code).toBe('UNAUTHORIZED');
+    });
+
+    it('debería retornar 500 si ocurre un error interno en la autenticación', async () => {
+      const mockError = new Error('Auth failure');
+      passport.authenticate.mockImplementation((_strategy, _options, callback) => {
+        return (_req, _res, _next) => {
+          callback(mockError, null, null);
+        };
+      });
+
+      const { authenticateLocal } = await import('../../src/middlewares/auth.middleware.js');
+      await authenticateLocal(req, res, next);
+
+      expect(next).toHaveBeenCalledWith(mockError);
     });
   });
 });

--- a/tp-final-integrador/tests/modules/auth.test.js
+++ b/tp-final-integrador/tests/modules/auth.test.js
@@ -12,19 +12,18 @@ describe('Auth Integration Tests', () => {
     it('debería iniciar sesión correctamente con credenciales válidas', async () => {
       const response = await request(app).post('/api/v1/auth/login').send({
         email: 'ferben@correo.com',
-        password: 'password123',
+        contrasenia: 'password123',
       });
 
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
       expect(response.body.data.token).toBeDefined();
-      expect(response.body.data.user.email).toBe('ferben@correo.com');
     });
 
     it('debería fallar con credenciales incorrectas', async () => {
       const response = await request(app).post('/api/v1/auth/login').send({
         email: 'ferben@correo.com',
-        password: 'wrong',
+        contrasenia: 'wrong',
       });
 
       expect(response.status).toBe(401);
@@ -35,7 +34,7 @@ describe('Auth Integration Tests', () => {
     it('debería fallar con datos de entrada inválidos (express-validator)', async () => {
       const response = await request(app).post('/api/v1/auth/login').send({
         email: 'not-an-email',
-        password: '',
+        contrasenia: '',
       });
 
       expect(response.status).toBe(422);

--- a/tp-final-integrador/tests/modules/obras_sociales.test.js
+++ b/tp-final-integrador/tests/modules/obras_sociales.test.js
@@ -803,7 +803,7 @@ describe('Obras Sociales - Integration Tests', () => {
 
       // 2. Insertamos usuario para el paciente
       const [userResult] = await pool.execute(
-        'INSERT INTO usuarios (documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+        'INSERT INTO usuarios (documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, SHA2(?, 256), ?, ?, ?)',
         ['55555555', 'Paciente', 'Test', 'paciente@test.com', 'password', '', ROLES.PACIENTE, 1],
       );
       const idUsuario = userResult.insertId;

--- a/tp-final-integrador/tests/modules/usuarios.model.test.js
+++ b/tp-final-integrador/tests/modules/usuarios.model.test.js
@@ -8,18 +8,19 @@ describe('Usuarios Model', () => {
     await setupTestDB();
   });
 
-  it('debe encontrar un usuario por su email', async () => {
+  it('debe encontrar un usuario por sus credenciales', async () => {
     const email = 'ferben@correo.com';
-    const user = await usuariosModel.findByEmail(email);
+    const password = 'password123';
+    const user = await usuariosModel.findByCredentials(email, password);
 
     expect(user).toBeDefined();
-    expect(user.email).toBe(email);
-    expect(user.id_usuario).toBeDefined();
+    expect(user.id).toBeDefined();
     expect(user.rol).toBe(ROLES.ADMIN);
+    expect(user.nombreCompleto).toBeDefined();
   });
 
-  it('debe devolver null si el email no existe', async () => {
-    const user = await usuariosModel.findByEmail('inexistente@correo.com');
+  it('debe devolver null si las credenciales son inválidas', async () => {
+    const user = await usuariosModel.findByCredentials('ferben@correo.com', 'wrongpassword');
     expect(user).toBeNull();
   });
 });

--- a/tp-final-integrador/tests/setup/seed.js
+++ b/tp-final-integrador/tests/setup/seed.js
@@ -1,17 +1,13 @@
-import bcryptjs from 'bcryptjs';
 import { ROLES } from '../../src/constants/roles.constants.js';
 import { pool } from '../../src/config/db.js';
 
 export async function seedTestUser() {
-  const salt = await bcryptjs.genSalt(10);
-  const hashedPassword = await bcryptjs.hash('password123', salt);
-
   // Limpiamos usuario de prueba existente (Benito)
   await pool.execute('DELETE FROM usuarios WHERE email = ?', ['ferben@correo.com']);
 
-  // Insertamos a Benito Fernandez (Admin) con hash bcrypt
+  // Insertamos a Benito Fernandez (Admin) con hash SHA2-256 y id_usuario = 8
   await pool.execute(
-    'INSERT INTO usuarios (documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
-    ['51000111', 'Fernandez', 'Benito', 'ferben@correo.com', hashedPassword, '', ROLES.ADMIN, 1],
+    'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, SHA2(?, 256), ?, ?, ?)',
+    [8, '51000111', 'Fernandez', 'Benito', 'ferben@correo.com', 'password123', '', ROLES.ADMIN, 1],
   );
 }


### PR DESCRIPTION
Este PR realiza la migración del sistema de autenticación y autorización para utilizar Passport.js (LocalStrategy y JwtStrategy), además de actualizar el hashing de contraseñas de bcrypt a MySQL SHA2(?, 256) según lo especificado.

### Cambios principales:
1. **Passport.js e Integración:** Se agregaron las dependencias y se configuraron las estrategias local (email/contrasenia) y JWT en `passport.js`.
2. **Mapeo en DAL:** Se creó `usuarios.mapper.js` para mapear los registros de usuarios a `camelCase` en la capa de datos (`findById` y `findByCredentials`).
3. **Flujo de Login y JWT:** Se adaptó `authService.login` para comparar con SHA2 en la base de datos, remover `documento` del payload del JWT y retornar en `camelCase`.
4. **Middleware de Autenticación:** Se encapsuló `authenticateLocal` en `auth.middleware.js` y se renombró `verifyToken` a `authenticateJwt` para mayor claridad semántica.
5. **Colección de Bruno:** Se incorporaron los endpoints de autenticación y se adaptó la colección para usar dinámicamente la variable `authToken`.

Relacionado con #51