### PR TITLE
fix: resolución de errores en DB_STATUS, caché y gestión de médicos

### DIFF
--- a/tp-final-integrador/bruno-collection/auth/login.bru
+++ b/tp-final-integrador/bruno-collection/auth/login.bru
@@ -18,13 +18,21 @@ headers {
 body:json {
   {
     "email": "ferben@correo.com",
-    "contrasenia": "password123"
+    "contrasenia": "ferben"
   }
 }
 
 script:post-response {
-  if (res.body && res.body.success && res.body.data && res.body.data.token) {
-    bru.setVar("authToken", res.body.data.token);
+  let body = res.body;
+  if (typeof body === 'string') {
+    try {
+      body = JSON.parse(body);
+    } catch (e) {}
+  }
+  const token = body && (body.token || (body.data && body.data.token));
+  if (token) {
+    bru.setEnvVar("authToken", token);
+    bru.setVar("authToken", token);
   }
 }
 
@@ -32,4 +40,3 @@ docs {
   Inicia sesión de un usuario con sus credenciales (email y contrasenia).
   Retorna un JWT de acceso en la respuesta y guarda el token en la variable `authToken`.
 }
-​

--- a/tp-final-integrador/bruno-collection/environments/Development.bru
+++ b/tp-final-integrador/bruno-collection/environments/Development.bru
@@ -1,4 +1,3 @@
 vars {
   baseUrl: http://localhost:3000/api/v1
-  authToken: 
 }

--- a/tp-final-integrador/bruno-collection/medicos/asociar-obras-sociales.bru
+++ b/tp-final-integrador/bruno-collection/medicos/asociar-obras-sociales.bru
@@ -19,6 +19,10 @@ body:json {
     "obrasSociales": [1, 2]
   }
 }
+headers {
+  Accept: application/json
+  Authorization: Bearer {{authToken}}
+}
 
 docs {
   Asocia una o más obras sociales a un médico.

--- a/tp-final-integrador/bruno-collection/turnos/error-fecha-pasada.bru
+++ b/tp-final-integrador/bruno-collection/turnos/error-fecha-pasada.bru
@@ -19,6 +19,10 @@ body:json {
     "hora": "10:00"
   }
 }
+headers {
+  Accept: application/json
+  Authorization: Bearer {{authToken}}
+}
 
 docs {
   Prueba de validación: el sistema debe retornar 422 si la fecha es anterior a la actual.

--- a/tp-final-integrador/bruno-collection/turnos/folder.bru
+++ b/tp-final-integrador/bruno-collection/turnos/folder.bru
@@ -2,7 +2,3 @@ meta {
   name: Turnos Reserva
   type: "folder"
 }
-
-auth {
-  mode: "bearer"
-}

--- a/tp-final-integrador/bruno-collection/turnos/registrar-obra-social.bru
+++ b/tp-final-integrador/bruno-collection/turnos/registrar-obra-social.bru
@@ -7,7 +7,6 @@ meta {
 post {
   url: {{baseUrl}}/turnos
   body: json
-  auth: inherit
 }
 
 body:json {
@@ -18,6 +17,10 @@ body:json {
     "fecha": "2026-07-15",
     "hora": "14:30"
   }
+}
+headers {
+  Accept: application/json
+  Authorization: Bearer {{authToken}}
 }
 
 docs {

--- a/tp-final-integrador/bruno-collection/turnos/registrar-particular.bru
+++ b/tp-final-integrador/bruno-collection/turnos/registrar-particular.bru
@@ -7,7 +7,6 @@ meta {
 post {
   url: {{baseUrl}}/turnos
   body: json
-  auth: inherit
 }
 
 body:json {
@@ -18,6 +17,10 @@ body:json {
     "fecha": "2026-07-16",
     "hora": "09:00"
   }
+}
+headers {
+  Accept: application/json
+  Authorization: Bearer {{authToken}}
 }
 
 docs {

--- a/tp-final-integrador/src/database/medicos.js
+++ b/tp-final-integrador/src/database/medicos.js
@@ -1,5 +1,6 @@
 import { pool } from '../config/db.js';
 import * as medicosMapper from './medicos.mapper.js';
+import { DB_STATUS } from '../constants/common.constants.js';
 
 /**
  * Busca un médico por su ID.
@@ -32,4 +33,65 @@ export const acceptsObraSocial = async (idMedico, idObraSocial) => {
   `;
   const [rows] = await pool.execute(query, [idMedico, idObraSocial, DB_STATUS.ACTIVE]);
   return rows.length > 0;
+};
+
+/**
+ * Obtiene los IDs de las obras sociales activas asociadas a un médico.
+ * @param {number} idMedico
+ * @returns {Promise<number[]>}
+ */
+export const getObrasSocialesIds = async (idMedico) => {
+  const query = `
+    SELECT id_obra_social FROM medicos_obras_sociales
+    WHERE id_medico = ? AND activo = ?
+  `;
+  const [rows] = await pool.execute(query, [idMedico, DB_STATUS.ACTIVE]);
+  return rows.map((row) => row.id_obra_social);
+};
+
+/**
+ * Asocia una lista de obras sociales a un médico.
+ * Si ya existe una relación inactiva, la reactiva. Si no existe, la crea.
+ * @param {number} idMedico
+ * @param {number[]} idsObrasSociales
+ * @returns {Promise<boolean>}
+ */
+export const assignObrasSociales = async (idMedico, idsObrasSociales) => {
+  const connection = await pool.getConnection();
+  try {
+    await connection.beginTransaction();
+
+    for (const idObraSocial of idsObrasSociales) {
+      const checkQuery = `
+        SELECT id_medico_obra_social, activo FROM medicos_obras_sociales
+        WHERE id_medico = ? AND id_obra_social = ?
+      `;
+      const [rows] = await connection.execute(checkQuery, [idMedico, idObraSocial]);
+
+      if (rows.length > 0) {
+        if (rows[0].activo !== DB_STATUS.ACTIVE) {
+          const updateQuery = `
+            UPDATE medicos_obras_sociales
+            SET activo = ?
+            WHERE id_medico_obra_social = ?
+          `;
+          await connection.execute(updateQuery, [DB_STATUS.ACTIVE, rows[0].id_medico_obra_social]);
+        }
+      } else {
+        const insertQuery = `
+          INSERT INTO medicos_obras_sociales (id_medico, id_obra_social, activo)
+          VALUES (?, ?, ?)
+        `;
+        await connection.execute(insertQuery, [idMedico, idObraSocial, DB_STATUS.ACTIVE]);
+      }
+    }
+
+    await connection.commit();
+    return true;
+  } catch (error) {
+    await connection.rollback();
+    throw error;
+  } finally {
+    connection.release();
+  }
 };

--- a/tp-final-integrador/src/database/obras_sociales.js
+++ b/tp-final-integrador/src/database/obras_sociales.js
@@ -107,10 +107,10 @@ export const findByIds = async (ids) => {
   const query = `
     SELECT id_obra_social, nombre, descripcion, porcentaje_descuento, es_particular, activo
     FROM obras_sociales
-    WHERE id_obra_social IN (${placeholders}) AND activo = 1
+    WHERE id_obra_social IN (${placeholders}) AND activo = ?
   `;
 
-  const [rows] = await pool.query(query, ids);
+  const [rows] = await pool.query(query, [...ids, DB_STATUS.ACTIVE]);
   return obrasSocialesMapper.toDTOList(rows);
 };
 

--- a/tp-final-integrador/src/routes/medicos.routes.js
+++ b/tp-final-integrador/src/routes/medicos.routes.js
@@ -3,8 +3,8 @@ import * as medicosController from '../controllers/medicos.controller.js';
 import * as medicosValidator from '../validators/medicos.validator.js';
 import { validateRequest } from '../middlewares/validate.middleware.js';
 import { methodNotAllowedHandler } from '../middlewares/method-not-allowed.middleware.js';
-// import { verifyToken, requireRole } from '../middlewares/auth.middleware.js';
-// import { ROLES } from '../constants/roles.constants.js';
+import { authenticateJwt, requireRole } from '../middlewares/auth.middleware.js';
+import { ROLES } from '../constants/roles.constants.js';
 
 const router = Router();
 
@@ -15,8 +15,8 @@ const router = Router();
 router
   .route('/:id_medico/obras-sociales')
   .post(
-    // verifyToken,
-    // requireRole([ROLES.ADMIN]),
+    authenticateJwt,
+    requireRole([ROLES.ADMIN]),
     medicosValidator.validateAsociarObrasSociales,
     validateRequest,
     medicosController.asociarObrasSociales,

--- a/tp-final-integrador/src/routes/turnos.routes.js
+++ b/tp-final-integrador/src/routes/turnos.routes.js
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import * as turnosController from '../controllers/turnos.controller.js';
 import * as turnosValidator from '../validators/turnos.validator.js';
 import { ROLES } from '../constants/roles.constants.js';
-import { verifyToken, requireRole } from '../middlewares/auth.middleware.js';
+import { authenticateJwt, requireRole } from '../middlewares/auth.middleware.js';
 import { validateRequest } from '../middlewares/validate.middleware.js';
 import { methodNotAllowedHandler } from '../middlewares/method-not-allowed.middleware.js';
 
@@ -13,7 +13,7 @@ const turnosRouter = Router();
  * Solo el Administrador (Role 3) puede registrar turnos.
  */
 
-turnosRouter.use(verifyToken);
+turnosRouter.use(authenticateJwt);
 turnosRouter.use(requireRole([ROLES.ADMIN]));
 
 turnosRouter

--- a/tp-final-integrador/tests/modules/cache.integration.test.js
+++ b/tp-final-integrador/tests/modules/cache.integration.test.js
@@ -51,7 +51,7 @@ describe('Cache Integration Tests', () => {
       .send({
         nombre: 'Nueva OS Cache Inval',
         descripcion: 'Test cache invalidation',
-        porcentajeDescuento: 10,
+        porcentajeDescuento: 0.1,
         esParticular: false,
       });
 

--- a/tp-final-integrador/tests/modules/medicos.test.js
+++ b/tp-final-integrador/tests/modules/medicos.test.js
@@ -4,8 +4,7 @@ import { app } from '../../src/app.js';
 import { pool } from '../../src/config/db.js';
 import { setupTestDB } from '../setup/db.js';
 
-// eslint-disable-next-line vitest/no-disabled-tests
-describe.skip('Médicos - Integration Tests', () => {
+describe('Médicos - Integration Tests', () => {
   let medicoId;
   let osActivaId1;
   let osActivaId2;
@@ -18,7 +17,7 @@ describe.skip('Médicos - Integration Tests', () => {
     // 0. Login para obtener token
     const loginRes = await request(app).post('/api/v1/auth/login').send({
       email: 'ferben@correo.com',
-      password: 'password123',
+      contrasenia: 'password123',
     });
     adminToken = loginRes.body.data.token;
 


### PR DESCRIPTION
Este PR corrige errores críticos en la infraestructura de base de datos y pruebas:

- **Base de Datos**: Se implementan las funciones faltantes para la asociación de médicos y obras sociales, y se estandariza el uso de la constante DB_STATUS para evitar ReferenceErrors.
- **Rutas y Seguridad**: Se migra a authenticateJwt y se activa la protección de roles para administradores en médicos y turnos.
- **Tests**: Se habilitan los tests de médicos y se corrige la validación de porcentajes en la integración de caché.
- **Colección Bruno**: Se actualiza la colección con scripts de respuesta robustos para el manejo del token.

