### PR TITLE
feat(turnos): endpoint GET /turnos para listar turnos propios

### DIFF
--- a/tp-final-integrador/bruno-collection/auth/login.bru
+++ b/tp-final-integrador/bruno-collection/auth/login.bru
@@ -17,8 +17,8 @@ headers {
 
 body:json {
   {
-    "email": "gomsil@correo.com",
-    "contrasenia": "gomsil"
+    "email": "lopjac@correo.com",
+    "contrasenia": "lopjac"
   }
 }
 

--- a/tp-final-integrador/bruno-collection/auth/login.bru
+++ b/tp-final-integrador/bruno-collection/auth/login.bru
@@ -17,23 +17,16 @@ headers {
 
 body:json {
   {
-    "email": "ferben@correo.com",
-    "contrasenia": "ferben"
+    "email": "gomsil@correo.com",
+    "contrasenia": "gomsil"
   }
 }
 
 script:post-response {
-  let body = res.body;
-  if (typeof body === 'string') {
-    try {
-      body = JSON.parse(body);
-    } catch (e) {}
-  }
-  const token = body && (body.token || (body.data && body.data.token));
-  if (token) {
-    bru.setEnvVar("authToken", token);
-    bru.setVar("authToken", token);
-  }
+  const {data} = res.getBody();
+    if (Boolean(data) === true && Boolean(data.token) === true) {
+      bru.setVar("authToken", data.token);
+    }
 }
 
 docs {

--- a/tp-final-integrador/bruno-collection/collection.bru
+++ b/tp-final-integrador/bruno-collection/collection.bru
@@ -1,3 +1,11 @@
 meta {
   name: Clínica Médica API
 }
+
+auth {
+  mode: bearer
+}
+
+auth:bearer {
+  token: {{authToken}}
+}

--- a/tp-final-integrador/bruno-collection/health/health-check.bru
+++ b/tp-final-integrador/bruno-collection/health/health-check.bru
@@ -6,7 +6,8 @@ meta {
 
 get {
   url: {{baseUrl}}/health
-  auth: none
+  auth: inherit
+  body: none
 }
 
 docs {

--- a/tp-final-integrador/bruno-collection/medicos/asociar-obras-sociales.bru
+++ b/tp-final-integrador/bruno-collection/medicos/asociar-obras-sociales.bru
@@ -21,7 +21,6 @@ body:json {
 }
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 docs {

--- a/tp-final-integrador/bruno-collection/obras-sociales/Get All (Actives and not actives).bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/Get All (Actives and not actives).bru
@@ -7,12 +7,11 @@ meta {
 get {
   url: {{baseUrl}}/obras-sociales?activo=all
   body: none
-  auth: none
+  auth: inherit
 }
 
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 params:query {

--- a/tp-final-integrador/bruno-collection/obras-sociales/Get All Actives.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/Get All Actives.bru
@@ -7,10 +7,9 @@ meta {
 get {
   url: {{baseUrl}}/obras-sociales
   body: none
-  auth: none
+  auth: inherit
 }
 
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }

--- a/tp-final-integrador/bruno-collection/obras-sociales/Get All c params.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/Get All c params.bru
@@ -7,7 +7,7 @@ meta {
 get {
   url: {{baseUrl}}/obras-sociales?limit=10&offset=0&order=nombre&asc=true&nombre=OSUNER
   body: none
-  auth: none
+  auth: inherit
 }
 
 params:query {
@@ -20,7 +20,6 @@ params:query {
 
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 script:pre-request {

--- a/tp-final-integrador/bruno-collection/obras-sociales/create.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/create.bru
@@ -7,13 +7,12 @@ meta {
 post {
   url: {{baseUrl}}/obras-sociales
   body: json
-  auth: none
+  auth: inherit
 }
 
 headers {
   Accept: application/json
   Content-Type: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 body:json {

--- a/tp-final-integrador/bruno-collection/obras-sociales/delete.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/delete.bru
@@ -7,12 +7,11 @@ meta {
 delete {
   url: {{baseUrl}}/obras-sociales/1
   body: none
-  auth: none
+  auth: inherit
 }
 
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 docs {

--- a/tp-final-integrador/bruno-collection/obras-sociales/get-by-id.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/get-by-id.bru
@@ -7,12 +7,11 @@ meta {
 get {
   url: {{baseUrl}}/obras-sociales/1
   body: none
-  auth: none
+  auth: inherit
 }
 
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 docs {

--- a/tp-final-integrador/bruno-collection/obras-sociales/update.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/update.bru
@@ -7,13 +7,12 @@ meta {
 put {
   url: {{baseUrl}}/obras-sociales/1
   body: json
-  auth: none
+  auth: inherit
 }
 
 headers {
   Accept: application/json
   Content-Type: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 body:json {

--- a/tp-final-integrador/bruno-collection/turnos/error-fecha-pasada.bru
+++ b/tp-final-integrador/bruno-collection/turnos/error-fecha-pasada.bru
@@ -21,7 +21,6 @@ body:json {
 }
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 docs {

--- a/tp-final-integrador/bruno-collection/turnos/listar-propios.bru
+++ b/tp-final-integrador/bruno-collection/turnos/listar-propios.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Listar Turnos Propios
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/turnos
+  body: none
+  auth: inherit
+}
+
+headers {
+  Accept: application/json
+}
+
+docs {
+  Obtiene la lista de turnos propios del usuario autenticado.
+  
+  - Si el usuario es **Médico**, verá sus turnos con datos del paciente.
+  - Si el usuario es **Paciente**, verá sus turnos con datos del médico.
+  - Requiere un token válido en la variable de entorno `authToken`.
+}

--- a/tp-final-integrador/bruno-collection/turnos/registrar-obra-social.bru
+++ b/tp-final-integrador/bruno-collection/turnos/registrar-obra-social.bru
@@ -6,6 +6,7 @@ meta {
 
 post {
   url: {{baseUrl}}/turnos
+  auth: inherit
   body: json
 }
 
@@ -20,7 +21,6 @@ body:json {
 }
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 docs {

--- a/tp-final-integrador/bruno-collection/turnos/registrar-particular.bru
+++ b/tp-final-integrador/bruno-collection/turnos/registrar-particular.bru
@@ -6,6 +6,7 @@ meta {
 
 post {
   url: {{baseUrl}}/turnos
+  auth: inherit
   body: json
 }
 
@@ -20,7 +21,6 @@ body:json {
 }
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 docs {

--- a/tp-final-integrador/docs/ENDPOINTS.md
+++ b/tp-final-integrador/docs/ENDPOINTS.md
@@ -45,6 +45,21 @@ Este documento detalla los endpoints disponibles en la API para facilitar las pr
 
 ---
 
+## 📅 Turnos (`/turnos`)
+
+| Método | Endpoint | Descripción | Acceso |
+| :--- | :--- | :--- | :--- |
+| `GET` | `/api/v1/turnos` | Listar turnos propios | Médico / Paciente |
+| `POST` | `/api/v1/turnos` | Registrar un nuevo turno | Admin |
+
+### Detalles de Turnos
+- El listado de turnos (`GET`) devuelve los turnos del usuario autenticado según su rol.
+- Si el usuario es **Médico**, el listado incluye datos del paciente y la obra social.
+- Si el usuario es **Paciente**, el listado incluye datos del médico, su especialidad y la obra social.
+- El registro de turnos (`POST`) calcula automáticamente el `valor_total` basándose en el valor de consulta del médico y el descuento de la obra social del paciente.
+
+---
+
 
 
 ---

--- a/tp-final-integrador/src/controllers/turnos.controller.js
+++ b/tp-final-integrador/src/controllers/turnos.controller.js
@@ -12,3 +12,8 @@ export const registrarTurno = async (req, res) => {
 
   return successResponse(res, nuevoTurno, 201);
 };
+
+export const listarTurnosPropios = async (req, res) => {
+  const turnos = await turnosService.listarTurnosPropios(req.user);
+  return successResponse(res, turnos);
+};

--- a/tp-final-integrador/src/database/medicos.js
+++ b/tp-final-integrador/src/database/medicos.js
@@ -21,6 +21,24 @@ export const findById = async (id) => {
 };
 
 /**
+ * Busca un médico por su ID de usuario.
+ * @param {number} idUsuario
+ * @returns {Promise<Object|null>}
+ */
+export const findByUserId = async (idUsuario) => {
+  const query = `
+    SELECT m.id_medico, m.id_usuario, m.id_especialidad, m.matricula, m.valor_consulta, u.activo
+    FROM medicos m
+    JOIN usuarios u ON m.id_usuario = u.id_usuario
+    WHERE m.id_usuario = ?
+  `;
+  const [rows] = await pool.execute(query, [idUsuario]);
+
+  if (rows.length === 0) return null;
+  return medicosMapper.toDTO(rows[0]);
+};
+
+/**
  * Verifica si un médico atiende una obra social específica de forma activa.
  * @param {number} idMedico
  * @param {number} idObraSocial

--- a/tp-final-integrador/src/database/pacientes.js
+++ b/tp-final-integrador/src/database/pacientes.js
@@ -18,3 +18,21 @@ export const findById = async (id) => {
   if (rows.length === 0) return null;
   return pacientesMapper.toDTO(rows[0]);
 };
+
+/**
+ * Busca un paciente por su ID de usuario.
+ * @param {number} idUsuario
+ * @returns {Promise<Object|null>}
+ */
+export const findByUserId = async (idUsuario) => {
+  const query = `
+    SELECT p.id_paciente, p.id_usuario, p.id_obra_social, u.activo
+    FROM pacientes p
+    JOIN usuarios u ON p.id_usuario = u.id_usuario
+    WHERE p.id_usuario = ?
+  `;
+  const [rows] = await pool.execute(query, [idUsuario]);
+
+  if (rows.length === 0) return null;
+  return pacientesMapper.toDTO(rows[0]);
+};

--- a/tp-final-integrador/src/database/turnos.js
+++ b/tp-final-integrador/src/database/turnos.js
@@ -1,5 +1,6 @@
 import { pool } from '../config/db.js';
 import { DB_STATUS } from '../constants/common.constants.js';
+import * as turnosMapper from './turnos.mapper.js';
 
 /**
  * Registra un nuevo turno.
@@ -24,6 +25,55 @@ export const create = async (data) => {
   ]);
 
   return result.insertId;
+};
+
+/**
+ * Obtiene los turnos de un médico.
+ * @param {number} idMedico
+ * @returns {Promise<Object[]>}
+ */
+export const findByMedicoId = async (idMedico) => {
+  const query = `
+    SELECT 
+      tr.*, 
+      u.apellido AS paciente_apellido, 
+      u.nombres AS paciente_nombres, 
+      u.email AS paciente_email, 
+      os.nombre AS obra_social_nombre
+    FROM turnos_reservas tr
+    JOIN pacientes p ON tr.id_paciente = p.id_paciente
+    JOIN usuarios u ON p.id_usuario = u.id_usuario
+    JOIN obras_sociales os ON tr.id_obra_social = os.id_obra_social
+    WHERE tr.id_medico = ? AND tr.activo = ?
+    ORDER BY tr.fecha_hora DESC
+  `;
+  const [rows] = await pool.execute(query, [idMedico, DB_STATUS.ACTIVE]);
+  return turnosMapper.toDTOs(rows, { omitirMedico: true });
+};
+
+/**
+ * Obtiene los turnos de un paciente.
+ * @param {number} idPaciente
+ * @returns {Promise<Object[]>}
+ */
+export const findByPacienteId = async (idPaciente) => {
+  const query = `
+    SELECT 
+      tr.*, 
+      u.apellido AS medico_apellido, 
+      u.nombres AS medico_nombres, 
+      e.nombre AS especialidad, 
+      os.nombre AS obra_social_nombre
+    FROM turnos_reservas tr
+    JOIN medicos m ON tr.id_medico = m.id_medico
+    JOIN usuarios u ON m.id_usuario = u.id_usuario
+    JOIN especialidades e ON m.id_especialidad = e.id_especialidad
+    JOIN obras_sociales os ON tr.id_obra_social = os.id_obra_social
+    WHERE tr.id_paciente = ? AND tr.activo = ?
+    ORDER BY tr.fecha_hora DESC
+  `;
+  const [rows] = await pool.execute(query, [idPaciente, DB_STATUS.ACTIVE]);
+  return turnosMapper.toDTOs(rows, { omitirPaciente: true });
 };
 
 /**

--- a/tp-final-integrador/src/database/turnos.mapper.js
+++ b/tp-final-integrador/src/database/turnos.mapper.js
@@ -1,0 +1,44 @@
+/**
+ * Mapper para la entidad Turno.
+ */
+
+export const toDTO = (row, options = {}) => {
+  if (!row) return null;
+
+  const { omitirMedico = false, omitirPaciente = false } = options;
+
+  return {
+    id: row.id_turno_reserva,
+    fechaHora: row.fecha_hora,
+    valorTotal: row.valor_total ? Number(row.valor_total) : 0,
+    atendido: Boolean(row.atendido),
+    activo: row.activo,
+    medico:
+      !omitirMedico && (row.medico_apellido || row.id_medico)
+        ? {
+            id: row.id_medico,
+            apellido: row.medico_apellido,
+            nombres: row.medico_nombres,
+            especialidad: row.especialidad,
+          }
+        : undefined,
+    paciente:
+      !omitirPaciente && (row.paciente_apellido || row.id_paciente)
+        ? {
+            id: row.id_paciente,
+            apellido: row.paciente_apellido,
+            nombres: row.paciente_nombres,
+            email: row.paciente_email,
+          }
+        : undefined,
+    obraSocial:
+      row.obra_social_nombre || row.id_obra_social
+        ? {
+            id: row.id_obra_social,
+            nombre: row.obra_social_nombre,
+          }
+        : undefined,
+  };
+};
+
+export const toDTOs = (rows, options = {}) => rows.map((row) => toDTO(row, options));

--- a/tp-final-integrador/src/routes/turnos.routes.js
+++ b/tp-final-integrador/src/routes/turnos.routes.js
@@ -10,15 +10,19 @@ const turnosRouter = Router();
 
 /**
  * Rutas para el módulo de Turnos.
- * Solo el Administrador (Role 3) puede registrar turnos.
  */
 
 turnosRouter.use(authenticateJwt);
-turnosRouter.use(requireRole([ROLES.ADMIN]));
 
 turnosRouter
   .route('/')
-  .post(turnosValidator.validateRegistrarTurno, validateRequest, turnosController.registrarTurno)
-  .all(methodNotAllowedHandler(['POST']));
+  .get(requireRole([ROLES.MEDICO, ROLES.PACIENTE]), turnosController.listarTurnosPropios)
+  .post(
+    requireRole([ROLES.ADMIN]),
+    turnosValidator.validateRegistrarTurno,
+    validateRequest,
+    turnosController.registrarTurno,
+  )
+  .all(methodNotAllowedHandler(['GET', 'POST']));
 
 export default turnosRouter;

--- a/tp-final-integrador/src/services/turnos.service.js
+++ b/tp-final-integrador/src/services/turnos.service.js
@@ -4,6 +4,35 @@ import * as pacientesModel from '../database/pacientes.js';
 import * as obrasSocialesModel from '../database/obras_sociales.js';
 import { AppError, ERROR_CODES } from '../helpers/errors.helper.js';
 import { DB_STATUS } from '../constants/common.constants.js';
+import { ROLES } from '../constants/roles.constants.js';
+
+/**
+ * Obtiene los turnos propios del usuario según su rol.
+ * @param {Object} usuario - El usuario autenticado (extraído de req.user).
+ * @returns {Promise<Object[]>} Lista de turnos.
+ */
+export const listarTurnosPropios = async (usuario) => {
+  if (usuario.rol === ROLES.MEDICO) {
+    const medico = await medicosModel.findByUserId(usuario.id);
+    if (!medico) {
+      throw new AppError(ERROR_CODES.NOT_FOUND, 'Perfil de médico no encontrado');
+    }
+    return await turnosModel.findByMedicoId(medico.idMedico);
+  }
+
+  if (usuario.rol === ROLES.PACIENTE) {
+    const paciente = await pacientesModel.findByUserId(usuario.id);
+    if (!paciente) {
+      throw new AppError(ERROR_CODES.NOT_FOUND, 'Perfil de paciente no encontrado');
+    }
+    return await turnosModel.findByPacienteId(paciente.idPaciente);
+  }
+
+  throw new AppError(
+    ERROR_CODES.FORBIDDEN,
+    'El rol del usuario no tiene permisos para esta acción',
+  );
+};
 
 /**
  * Registra un nuevo turno con cálculo de valor_total.

--- a/tp-final-integrador/src/services/turnos.service.js
+++ b/tp-final-integrador/src/services/turnos.service.js
@@ -7,24 +7,44 @@ import { DB_STATUS } from '../constants/common.constants.js';
 import { ROLES } from '../constants/roles.constants.js';
 
 /**
+ * Busca una entidad por ID y lanza un error si no existe o no está activa.
+ * @param {Function} findFn - Función async que recibe el ID y retorna la entidad o null.
+ * @param {*} id - El ID a buscar.
+ * @param {Object} messages - Mensajes de error personalizados.
+ * @param {string} messages.notFoundMessage - Mensaje cuando la entidad no existe.
+ * @param {string} messages.inactiveMessage - Mensaje cuando la entidad está inactiva.
+ * @returns {Promise<Object>} La entidad encontrada y activa.
+ */
+const findActiveOrThrow = async (findFn, id, { notFoundMessage, inactiveMessage }) => {
+  const entity = await findFn(id);
+  if (!entity) {
+    throw new AppError(ERROR_CODES.NOT_FOUND, notFoundMessage);
+  }
+  if (!entity.activo) {
+    throw new AppError(ERROR_CODES.VALIDATION_ERROR, inactiveMessage);
+  }
+  return entity;
+};
+
+/**
  * Obtiene los turnos propios del usuario según su rol.
  * @param {Object} usuario - El usuario autenticado (extraído de req.user).
  * @returns {Promise<Object[]>} Lista de turnos.
  */
 export const listarTurnosPropios = async (usuario) => {
   if (usuario.rol === ROLES.MEDICO) {
-    const medico = await medicosModel.findByUserId(usuario.id);
-    if (!medico) {
-      throw new AppError(ERROR_CODES.NOT_FOUND, 'Perfil de médico no encontrado');
-    }
+    const medico = await findActiveOrThrow(medicosModel.findByUserId, usuario.id, {
+      notFoundMessage: 'Perfil de médico no encontrado',
+      inactiveMessage: 'El médico solicitado no se encuentra activo',
+    });
     return await turnosModel.findByMedicoId(medico.idMedico);
   }
 
   if (usuario.rol === ROLES.PACIENTE) {
-    const paciente = await pacientesModel.findByUserId(usuario.id);
-    if (!paciente) {
-      throw new AppError(ERROR_CODES.NOT_FOUND, 'Perfil de paciente no encontrado');
-    }
+    const paciente = await findActiveOrThrow(pacientesModel.findByUserId, usuario.id, {
+      notFoundMessage: 'Perfil de paciente no encontrado',
+      inactiveMessage: 'El paciente solicitado no se encuentra activo',
+    });
     return await turnosModel.findByPacienteId(paciente.idPaciente);
   }
 
@@ -42,24 +62,15 @@ export const listarTurnosPropios = async (usuario) => {
 export const registrarTurno = async (data) => {
   const { idMedico, idPaciente, idObraSocial, fecha, hora } = data;
 
-  const medico = await medicosModel.findById(idMedico);
-  if (!medico) {
-    throw new AppError(ERROR_CODES.NOT_FOUND, 'El médico solicitado no existe');
-  }
-  if (!medico.activo) {
-    throw new AppError(ERROR_CODES.VALIDATION_ERROR, 'El médico solicitado no se encuentra activo');
-  }
+  const medico = await findActiveOrThrow(medicosModel.findById, idMedico, {
+    notFoundMessage: 'El médico solicitado no existe',
+    inactiveMessage: 'El médico solicitado no se encuentra activo',
+  });
 
-  const paciente = await pacientesModel.findById(idPaciente);
-  if (!paciente) {
-    throw new AppError(ERROR_CODES.NOT_FOUND, 'El paciente solicitado no existe');
-  }
-  if (!paciente.activo) {
-    throw new AppError(
-      ERROR_CODES.VALIDATION_ERROR,
-      'El paciente solicitado no se encuentra activo',
-    );
-  }
+  const paciente = await findActiveOrThrow(pacientesModel.findById, idPaciente, {
+    notFoundMessage: 'El paciente solicitado no existe',
+    inactiveMessage: 'El paciente solicitado no se encuentra activo',
+  });
 
   if (paciente.idObraSocial !== idObraSocial) {
     throw new AppError(
@@ -68,16 +79,14 @@ export const registrarTurno = async (data) => {
     );
   }
 
-  const obraSocial = await obrasSocialesModel.findById(idObraSocial, false);
-  if (!obraSocial) {
-    throw new AppError(ERROR_CODES.NOT_FOUND, 'La obra social solicitada no existe');
-  }
-  if (!obraSocial.activo) {
-    throw new AppError(
-      ERROR_CODES.VALIDATION_ERROR,
-      'La obra social solicitada no se encuentra activa',
-    );
-  }
+  const obraSocial = await findActiveOrThrow(
+    (id) => obrasSocialesModel.findById(id, false),
+    idObraSocial,
+    {
+      notFoundMessage: 'La obra social solicitada no existe',
+      inactiveMessage: 'La obra social solicitada no se encuentra activa',
+    },
+  );
 
   if (!obraSocial.esParticular) {
     const aceptaObraSocial = await medicosModel.acceptsObraSocial(idMedico, idObraSocial);

--- a/tp-final-integrador/tests/modules/turnos.list.test.js
+++ b/tp-final-integrador/tests/modules/turnos.list.test.js
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll } from 'vitest';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { app } from '../../src/app.js';
+import { pool } from '../../src/config/db.js';
+import { setupTestDB } from '../setup/db.js';
+import { ROLES } from '../../src/constants/roles.constants.js';
+
+describe('Turnos List - Integration Tests', () => {
+  let adminToken;
+  let patientToken;
+  let doctorToken;
+  const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+
+  beforeEach(async () => {
+    await setupTestDB();
+
+    // 1. Especialidad
+    await pool.execute(
+      'INSERT INTO especialidades (id_especialidad, nombre, activo) VALUES (?, ?, ?)',
+      [1, 'PEDIATRÍA', 1],
+    );
+
+    // 2. Obra Social
+    await pool.execute(
+      'INSERT INTO obras_sociales (id_obra_social, nombre, descripcion, porcentaje_descuento, es_particular, activo) VALUES (?, ?, ?, ?, ?, ?)',
+      [1, 'OSDE', 'Plan 210', 0.1, 0, 1],
+    );
+
+    // 3. Usuarios
+    await pool.execute(
+      'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      [1, '11111111', 'Admin', 'Root', 'admin@test.com', 'hash', '', ROLES.ADMIN, 1],
+    );
+    await pool.execute(
+      'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      [2, '22222222', 'Medico', 'Doc', 'medico@test.com', 'hash', '', ROLES.MEDICO, 1],
+    );
+    await pool.execute(
+      'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      [3, '33333333', 'Paciente', 'User', 'paciente@test.com', 'hash', '', ROLES.PACIENTE, 1],
+    );
+
+    // 4. Medico
+    await pool.execute(
+      'INSERT INTO medicos (id_medico, id_usuario, id_especialidad, matricula, valor_consulta) VALUES (?, ?, ?, ?, ?)',
+      [1, 2, 1, 2000, 5000.0],
+    );
+
+    // 5. Paciente
+    await pool.execute(
+      'INSERT INTO pacientes (id_paciente, id_usuario, id_obra_social) VALUES (?, ?, ?)',
+      [1, 3, 1],
+    );
+
+    // 6. Turno
+    await pool.execute(
+      'INSERT INTO turnos_reservas (id_medico, id_paciente, id_obra_social, fecha_hora, valor_total, atendido, activo) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      [1, 1, 1, '2026-07-15 14:30:00', 4500.0, 0, 1],
+    );
+
+    // Tokens
+    adminToken = jwt.sign({ id: 1, rol: ROLES.ADMIN, documento: '11111111' }, JWT_SECRET);
+    doctorToken = jwt.sign({ id: 2, rol: ROLES.MEDICO, documento: '22222222' }, JWT_SECRET);
+    patientToken = jwt.sign({ id: 3, rol: ROLES.PACIENTE, documento: '33333333' }, JWT_SECRET);
+  });
+
+  afterEach(async () => {
+    await setupTestDB(); // setupTestDB ya limpia la base
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  describe('GET /api/v1/turnos', () => {
+    it('Doctor should see their own turnos', async () => {
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${doctorToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(Array.isArray(response.body.data)).toBe(true);
+      expect(response.body.data.length).toBe(1);
+      expect(response.body.data[0].paciente).toBeDefined();
+      expect(response.body.data[0].paciente.id).toBe(1);
+      expect(response.body.data[0].paciente.apellido).toBe('Paciente');
+      expect(response.body.data[0].medico).toBeUndefined();
+    });
+
+    it('Patient should see their own turnos', async () => {
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${patientToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(Array.isArray(response.body.data)).toBe(true);
+      expect(response.body.data.length).toBe(1);
+      expect(response.body.data[0].medico).toBeDefined();
+      expect(response.body.data[0].medico.id).toBe(1);
+      expect(response.body.data[0].medico.apellido).toBe('Medico');
+      expect(response.body.data[0].paciente).toBeUndefined();
+    });
+
+    it('Admin should be forbidden from listing turnos (not a doctor or patient)', async () => {
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(response.status).toBe(403);
+    });
+
+    it('Doctor without profile should return 404', async () => {
+      // Create user with doctor role but no medicos entry
+      await pool.execute(
+        'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        [4, '44444444', 'Ghost', 'Doc', 'ghost@test.com', 'hash', '', ROLES.MEDICO, 1],
+      );
+      const ghostToken = jwt.sign({ id: 4, rol: ROLES.MEDICO, documento: '44444444' }, JWT_SECRET);
+
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${ghostToken}`);
+
+      expect(response.status).toBe(404);
+      expect(response.body.error.message).toBe('Perfil de médico no encontrado');
+    });
+
+    it('Patient without profile should return 404', async () => {
+      // Create user with patient role but no pacientes entry
+      await pool.execute(
+        'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        [5, '55555555', 'Ghost', 'Patient', 'ghostpatient@test.com', 'hash', '', ROLES.PACIENTE, 1],
+      );
+      const ghostToken = jwt.sign(
+        { id: 5, rol: ROLES.PACIENTE, documento: '55555555' },
+        JWT_SECRET,
+      );
+
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${ghostToken}`);
+
+      expect(response.status).toBe(404);
+      expect(response.body.error.message).toBe('Perfil de paciente no encontrado');
+    });
+
+    it('Should not list inactive turnos', async () => {
+      // Create an inactive turno
+      await pool.execute(
+        'INSERT INTO turnos_reservas (id_medico, id_paciente, id_obra_social, fecha_hora, valor_total, atendido, activo) VALUES (?, ?, ?, ?, ?, ?, ?)',
+        [1, 1, 1, '2026-07-16 10:00:00', 4500.0, 0, 0], // Activo = 0
+      );
+
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${patientToken}`);
+
+      expect(response.status).toBe(200);
+      // Should only see the active one from beforeEach
+      expect(response.body.data.length).toBe(1);
+      expect(response.body.data[0].fechaHora).not.toContain('2026-07-16 10:00:00');
+    });
+
+    it('Should return turnos ordered by date descending', async () => {
+      // Add a second turno for the same patient, but EARLIER than the one in beforeEach (2026-07-15 14:30:00)
+      await pool.execute(
+        'INSERT INTO turnos_reservas (id_medico, id_paciente, id_obra_social, fecha_hora, valor_total, atendido, activo) VALUES (?, ?, ?, ?, ?, ?, ?)',
+        [1, 1, 1, '2026-07-10 09:00:00', 4500.0, 0, 1],
+      );
+
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${patientToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.length).toBe(2);
+
+      // The first one should be the LATEST (July 15th)
+      const firstDate = new Date(response.body.data[0].fechaHora);
+      const secondDate = new Date(response.body.data[1].fechaHora);
+
+      expect(firstDate.getTime()).toBeGreaterThan(secondDate.getTime());
+      expect(response.body.data[0].fechaHora).toContain('2026-07-15');
+      expect(response.body.data[1].fechaHora).toContain('2026-07-10');
+    });
+
+    it('Should return an empty array if no turnos found', async () => {
+      // Create a new patient without turnos
+      await pool.execute(
+        'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        [6, '66666666', 'New', 'Patient', 'new@test.com', 'hash', '', ROLES.PACIENTE, 1],
+      );
+      await pool.execute(
+        'INSERT INTO pacientes (id_paciente, id_usuario, id_obra_social) VALUES (?, ?, ?)',
+        [2, 6, 1],
+      );
+      const newToken = jwt.sign({ id: 6, rol: ROLES.PACIENTE, documento: '66666666' }, JWT_SECRET);
+
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${newToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data).toEqual([]);
+    });
+
+    it('Should return 401 if no token is provided', async () => {
+      const response = await request(app).get('/api/v1/turnos');
+      expect(response.status).toBe(401);
+    });
+  });
+});

--- a/tp-final-integrador/tests/modules/turnos.service.test.js
+++ b/tp-final-integrador/tests/modules/turnos.service.test.js
@@ -4,20 +4,25 @@ import * as turnosModel from '../../src/database/turnos.js';
 import * as medicosModel from '../../src/database/medicos.js';
 import * as pacientesModel from '../../src/database/pacientes.js';
 import * as obrasSocialesModel from '../../src/database/obras_sociales.js';
+import { ROLES } from '../../src/constants/roles.constants.js';
 
 vi.mock('../../src/database/turnos.js', () => ({
   create: vi.fn(),
   checkPatientOverlap: vi.fn(),
   existsByMedicoAndFechaHora: vi.fn(),
+  findByMedicoId: vi.fn(),
+  findByPacienteId: vi.fn(),
 }));
 
 vi.mock('../../src/database/medicos.js', () => ({
   findById: vi.fn(),
+  findByUserId: vi.fn(),
   acceptsObraSocial: vi.fn(),
 }));
 
 vi.mock('../../src/database/pacientes.js', () => ({
   findById: vi.fn(),
+  findByUserId: vi.fn(),
 }));
 
 vi.mock('../../src/database/obras_sociales.js', () => ({
@@ -30,6 +35,65 @@ describe('Turnos Service - Unit Tests', () => {
     medicosModel.acceptsObraSocial.mockResolvedValue(true);
     turnosModel.checkPatientOverlap.mockResolvedValue(false);
     turnosModel.existsByMedicoAndFechaHora.mockResolvedValue(false);
+  });
+
+  describe('listarTurnosPropios()', () => {
+    it('debería retornar los turnos del médico cuando el rol es MEDICO', async () => {
+      const mockMedico = { idMedico: 1 };
+      const mockTurnos = [{ id: 1, fecha: '2026-07-15' }];
+      medicosModel.findByUserId.mockResolvedValue(mockMedico);
+      turnosModel.findByMedicoId.mockResolvedValue(mockTurnos);
+
+      const result = await turnosService.listarTurnosPropios({ id: 2, rol: ROLES.MEDICO });
+
+      expect(medicosModel.findByUserId).toHaveBeenCalledWith(2);
+      expect(turnosModel.findByMedicoId).toHaveBeenCalledWith(1);
+      expect(result).toEqual(mockTurnos);
+    });
+
+    it('debería lanzar NOT_FOUND si el médico no tiene perfil', async () => {
+      medicosModel.findByUserId.mockResolvedValue(null);
+
+      await expect(
+        turnosService.listarTurnosPropios({ id: 99, rol: ROLES.MEDICO }),
+      ).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+        message: 'Perfil de médico no encontrado',
+      });
+    });
+
+    it('debería retornar los turnos del paciente cuando el rol es PACIENTE', async () => {
+      const mockPaciente = { idPaciente: 5 };
+      const mockTurnos = [{ id: 2, fecha: '2026-08-10' }];
+      pacientesModel.findByUserId.mockResolvedValue(mockPaciente);
+      turnosModel.findByPacienteId.mockResolvedValue(mockTurnos);
+
+      const result = await turnosService.listarTurnosPropios({ id: 3, rol: ROLES.PACIENTE });
+
+      expect(pacientesModel.findByUserId).toHaveBeenCalledWith(3);
+      expect(turnosModel.findByPacienteId).toHaveBeenCalledWith(5);
+      expect(result).toEqual(mockTurnos);
+    });
+
+    it('debería lanzar NOT_FOUND si el paciente no tiene perfil', async () => {
+      pacientesModel.findByUserId.mockResolvedValue(null);
+
+      await expect(
+        turnosService.listarTurnosPropios({ id: 99, rol: ROLES.PACIENTE }),
+      ).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+        message: 'Perfil de paciente no encontrado',
+      });
+    });
+
+    it('debería lanzar FORBIDDEN si el rol no es médico ni paciente', async () => {
+      await expect(
+        turnosService.listarTurnosPropios({ id: 1, rol: 'admin' }),
+      ).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+        message: 'El rol del usuario no tiene permisos para esta acción',
+      });
+    });
   });
 
   describe('registrarTurno() - Calculation Logic', () => {

--- a/tp-final-integrador/tests/setup/db.js
+++ b/tp-final-integrador/tests/setup/db.js
@@ -13,13 +13,13 @@ export const clearDatabase = async () => {
   try {
     await pool.execute('SET FOREIGN_KEY_CHECKS = 0');
 
-    // Lista de tablas a limpiar (en orden de dependencia si fuera necesario, aunque con checks en 0 no importa tanto)
+    // Lista de tablas a limpiar
     const tables = [
+      'especialidades',
       'turnos_reservas',
       'medicos_obras_sociales',
       'pacientes',
       'medicos',
-      'especialidades',
       'obras_sociales',
       'usuarios',
     ];


### PR DESCRIPTION
Closes #82

## Tipo de cambio

- [x] Nueva funcionalidad

## Resumen

- Implementa `GET /api/v1/turnos` para que médicos y pacientes puedan consultar sus propios turnos según su rol.
- El acceso a `POST /api/v1/turnos` (registrar turno) queda exclusivo del administrador, con la guardia de rol aplicada por método en lugar de globalmente en el router.
- Incluye un mapper dedicado (`turnos.mapper.js`) para transformar las filas crudas de la DB en objetos de dominio ricos.

## Cambios

| Archivo | Cambio |
|---------|--------|
| `src/database/medicos.js` | Agrega `findByUserId()` |
| `src/database/pacientes.js` | Agrega `findByUserId()` |
| `src/database/turnos.js` | Agrega `findByMedicoId()` y `findByPacienteId()` con JOIN enriquecido |
| `src/database/turnos.mapper.js` | Nuevo mapper: transforma filas DB en objetos de dominio |
| `src/services/turnos.service.js` | Agrega `listarTurnosPropios(usuario)` con lógica por rol |
| `src/routes/turnos.routes.js` | Expone `GET /` para MEDICO y PACIENTE; guardia por método |
| `src/controllers/turnos.controller.js` | Agrega handler `listarTurnosPropios` |
| `tests/modules/turnos.service.test.js` | 5 tests unitarios del service (happy path + errores por rol) |
| `tests/modules/turnos.list.test.js` | 8 tests de integración del endpoint (roles, 401, 403, 404, orden, inactivos) |
| `tests/setup/db.js` | Corrige orden de limpieza de tablas para evitar FK violations |
| `docs/ENDPOINTS.md` | Documenta la sección de turnos con detalles de respuesta por rol |
| `bruno-collection/turnos/listar-propios.bru` | Nuevo request en la colección Bruno |
| `bruno-collection/**/*.bru` | Actualización de metadatos de la colección |

