### PR TITLE
feat(turnos): permitir al medico marcar turno como atendido

### DIFF
--- a/tp-final-integrador/bruno-collection/auth/login.bru
+++ b/tp-final-integrador/bruno-collection/auth/login.bru
@@ -17,8 +17,8 @@ headers {
 
 body:json {
   {
-    "email": "gomsil@correo.com",
-    "contrasenia": "gomsil"
+    "email": "lopjac@correo.com",
+    "contrasenia": "lopjac"
   }
 }
 

--- a/tp-final-integrador/bruno-collection/auth/login.bru
+++ b/tp-final-integrador/bruno-collection/auth/login.bru
@@ -17,23 +17,16 @@ headers {
 
 body:json {
   {
-    "email": "ferben@correo.com",
-    "contrasenia": "ferben"
+    "email": "gomsil@correo.com",
+    "contrasenia": "gomsil"
   }
 }
 
 script:post-response {
-  let body = res.body;
-  if (typeof body === 'string') {
-    try {
-      body = JSON.parse(body);
-    } catch (e) {}
-  }
-  const token = body && (body.token || (body.data && body.data.token));
-  if (token) {
-    bru.setEnvVar("authToken", token);
-    bru.setVar("authToken", token);
-  }
+  const {data} = res.getBody();
+    if (Boolean(data) === true && Boolean(data.token) === true) {
+      bru.setVar("authToken", data.token);
+    }
 }
 
 docs {

--- a/tp-final-integrador/bruno-collection/collection.bru
+++ b/tp-final-integrador/bruno-collection/collection.bru
@@ -1,3 +1,11 @@
 meta {
   name: Clínica Médica API
 }
+
+auth {
+  mode: bearer
+}
+
+auth:bearer {
+  token: {{authToken}}
+}

--- a/tp-final-integrador/bruno-collection/health/health-check.bru
+++ b/tp-final-integrador/bruno-collection/health/health-check.bru
@@ -6,7 +6,8 @@ meta {
 
 get {
   url: {{baseUrl}}/health
-  auth: none
+  auth: inherit
+  body: none
 }
 
 docs {

--- a/tp-final-integrador/bruno-collection/medicos/asociar-obras-sociales.bru
+++ b/tp-final-integrador/bruno-collection/medicos/asociar-obras-sociales.bru
@@ -21,7 +21,6 @@ body:json {
 }
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 docs {

--- a/tp-final-integrador/bruno-collection/obras-sociales/Get All (Actives and not actives).bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/Get All (Actives and not actives).bru
@@ -7,12 +7,11 @@ meta {
 get {
   url: {{baseUrl}}/obras-sociales?activo=all
   body: none
-  auth: none
+  auth: inherit
 }
 
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 params:query {

--- a/tp-final-integrador/bruno-collection/obras-sociales/Get All Actives.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/Get All Actives.bru
@@ -7,10 +7,9 @@ meta {
 get {
   url: {{baseUrl}}/obras-sociales
   body: none
-  auth: none
+  auth: inherit
 }
 
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }

--- a/tp-final-integrador/bruno-collection/obras-sociales/Get All c params.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/Get All c params.bru
@@ -7,7 +7,7 @@ meta {
 get {
   url: {{baseUrl}}/obras-sociales?limit=10&offset=0&order=nombre&asc=true&nombre=OSUNER
   body: none
-  auth: none
+  auth: inherit
 }
 
 params:query {
@@ -20,7 +20,6 @@ params:query {
 
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 script:pre-request {

--- a/tp-final-integrador/bruno-collection/obras-sociales/create.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/create.bru
@@ -7,13 +7,12 @@ meta {
 post {
   url: {{baseUrl}}/obras-sociales
   body: json
-  auth: none
+  auth: inherit
 }
 
 headers {
   Accept: application/json
   Content-Type: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 body:json {

--- a/tp-final-integrador/bruno-collection/obras-sociales/delete.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/delete.bru
@@ -7,12 +7,11 @@ meta {
 delete {
   url: {{baseUrl}}/obras-sociales/1
   body: none
-  auth: none
+  auth: inherit
 }
 
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 docs {

--- a/tp-final-integrador/bruno-collection/obras-sociales/get-by-id.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/get-by-id.bru
@@ -7,12 +7,11 @@ meta {
 get {
   url: {{baseUrl}}/obras-sociales/1
   body: none
-  auth: none
+  auth: inherit
 }
 
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 docs {

--- a/tp-final-integrador/bruno-collection/obras-sociales/update.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/update.bru
@@ -7,13 +7,12 @@ meta {
 put {
   url: {{baseUrl}}/obras-sociales/1
   body: json
-  auth: none
+  auth: inherit
 }
 
 headers {
   Accept: application/json
   Content-Type: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 body:json {

--- a/tp-final-integrador/bruno-collection/turnos/error-fecha-pasada.bru
+++ b/tp-final-integrador/bruno-collection/turnos/error-fecha-pasada.bru
@@ -21,7 +21,6 @@ body:json {
 }
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 docs {

--- a/tp-final-integrador/bruno-collection/turnos/listar-propios.bru
+++ b/tp-final-integrador/bruno-collection/turnos/listar-propios.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Listar Turnos Propios
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/turnos
+  body: none
+  auth: inherit
+}
+
+headers {
+  Accept: application/json
+}
+
+docs {
+  Obtiene la lista de turnos propios del usuario autenticado.
+  
+  - Si el usuario es **Médico**, verá sus turnos con datos del paciente.
+  - Si el usuario es **Paciente**, verá sus turnos con datos del médico.
+  - Requiere un token válido en la variable de entorno `authToken`.
+}

--- a/tp-final-integrador/bruno-collection/turnos/marcar-atendido.bru
+++ b/tp-final-integrador/bruno-collection/turnos/marcar-atendido.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Marcar Turno como Atendido
+  type: http
+  seq: 5
+}
+
+patch {
+  url: {{baseUrl}}/turnos/:id/atendido
+  body: none
+  auth: inherit
+}
+
+params:path {
+  id: 1
+}
+
+headers {
+  Accept: application/json
+}
+
+docs {
+  Permite a un médico marcar uno de sus turnos asignados como atendido.
+  
+  - **Acceso**: Solo Médicos.
+  - **Validación**: Solo puede marcar turnos que le pertenecen.
+  - **Idempotencia**: Si el turno ya fue atendido, retorna un error 409 Conflict.
+}

--- a/tp-final-integrador/bruno-collection/turnos/registrar-obra-social.bru
+++ b/tp-final-integrador/bruno-collection/turnos/registrar-obra-social.bru
@@ -6,6 +6,7 @@ meta {
 
 post {
   url: {{baseUrl}}/turnos
+  auth: inherit
   body: json
 }
 
@@ -20,7 +21,6 @@ body:json {
 }
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 docs {

--- a/tp-final-integrador/bruno-collection/turnos/registrar-particular.bru
+++ b/tp-final-integrador/bruno-collection/turnos/registrar-particular.bru
@@ -6,6 +6,7 @@ meta {
 
 post {
   url: {{baseUrl}}/turnos
+  auth: inherit
   body: json
 }
 
@@ -20,7 +21,6 @@ body:json {
 }
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 docs {

--- a/tp-final-integrador/docs/ENDPOINTS.md
+++ b/tp-final-integrador/docs/ENDPOINTS.md
@@ -45,6 +45,21 @@ Este documento detalla los endpoints disponibles en la API para facilitar las pr
 
 ---
 
+## 📅 Turnos (`/turnos`)
+
+| Método | Endpoint | Descripción | Acceso |
+| :--- | :--- | :--- | :--- |
+| `GET` | `/api/v1/turnos` | Listar turnos propios | Médico / Paciente |
+| `POST` | `/api/v1/turnos` | Registrar un nuevo turno | Admin |
+
+### Detalles de Turnos
+- El listado de turnos (`GET`) devuelve los turnos del usuario autenticado según su rol.
+- Si el usuario es **Médico**, el listado incluye datos del paciente y la obra social.
+- Si el usuario es **Paciente**, el listado incluye datos del médico, su especialidad y la obra social.
+- El registro de turnos (`POST`) calcula automáticamente el `valor_total` basándose en el valor de consulta del médico y el descuento de la obra social del paciente.
+
+---
+
 
 
 ---

--- a/tp-final-integrador/docs/ENDPOINTS.md
+++ b/tp-final-integrador/docs/ENDPOINTS.md
@@ -51,6 +51,7 @@ Este documento detalla los endpoints disponibles en la API para facilitar las pr
 | :--- | :--- | :--- | :--- |
 | `GET` | `/api/v1/turnos` | Listar turnos propios | Médico / Paciente |
 | `POST` | `/api/v1/turnos` | Registrar un nuevo turno | Admin |
+| `PATCH` | `/api/v1/turnos/:id/atendido` | Marcar turno como atendido | Médico |
 
 ### Detalles de Turnos
 - El listado de turnos (`GET`) devuelve los turnos del usuario autenticado según su rol.

--- a/tp-final-integrador/src/controllers/turnos.controller.js
+++ b/tp-final-integrador/src/controllers/turnos.controller.js
@@ -12,3 +12,8 @@ export const registrarTurno = async (req, res) => {
 
   return successResponse(res, nuevoTurno, 201);
 };
+
+export const listarTurnosPropios = async (req, res) => {
+  const turnos = await turnosService.listarTurnosPropios(req.user);
+  return successResponse(res, turnos);
+};

--- a/tp-final-integrador/src/controllers/turnos.controller.js
+++ b/tp-final-integrador/src/controllers/turnos.controller.js
@@ -17,3 +17,10 @@ export const listarTurnosPropios = async (req, res) => {
   const turnos = await turnosService.listarTurnosPropios(req.user);
   return successResponse(res, turnos);
 };
+
+export const marcarComoAtendido = async (req, res) => {
+  const { id } = matchedData(req);
+  const turnoActualizado = await turnosService.marcarComoAtendido(id, req.user.id);
+
+  return successResponse(res, turnoActualizado);
+};

--- a/tp-final-integrador/src/database/medicos.js
+++ b/tp-final-integrador/src/database/medicos.js
@@ -21,6 +21,24 @@ export const findById = async (id) => {
 };
 
 /**
+ * Busca un médico por su ID de usuario.
+ * @param {number} idUsuario
+ * @returns {Promise<Object|null>}
+ */
+export const findByUserId = async (idUsuario) => {
+  const query = `
+    SELECT m.id_medico, m.id_usuario, m.id_especialidad, m.matricula, m.valor_consulta, u.activo
+    FROM medicos m
+    JOIN usuarios u ON m.id_usuario = u.id_usuario
+    WHERE m.id_usuario = ?
+  `;
+  const [rows] = await pool.execute(query, [idUsuario]);
+
+  if (rows.length === 0) return null;
+  return medicosMapper.toDTO(rows[0]);
+};
+
+/**
  * Verifica si un médico atiende una obra social específica de forma activa.
  * @param {number} idMedico
  * @param {number} idObraSocial

--- a/tp-final-integrador/src/database/pacientes.js
+++ b/tp-final-integrador/src/database/pacientes.js
@@ -18,3 +18,21 @@ export const findById = async (id) => {
   if (rows.length === 0) return null;
   return pacientesMapper.toDTO(rows[0]);
 };
+
+/**
+ * Busca un paciente por su ID de usuario.
+ * @param {number} idUsuario
+ * @returns {Promise<Object|null>}
+ */
+export const findByUserId = async (idUsuario) => {
+  const query = `
+    SELECT p.id_paciente, p.id_usuario, p.id_obra_social, u.activo
+    FROM pacientes p
+    JOIN usuarios u ON p.id_usuario = u.id_usuario
+    WHERE p.id_usuario = ?
+  `;
+  const [rows] = await pool.execute(query, [idUsuario]);
+
+  if (rows.length === 0) return null;
+  return pacientesMapper.toDTO(rows[0]);
+};

--- a/tp-final-integrador/src/database/turnos.js
+++ b/tp-final-integrador/src/database/turnos.js
@@ -1,5 +1,6 @@
 import { pool } from '../config/db.js';
 import { DB_STATUS } from '../constants/common.constants.js';
+import * as turnosMapper from './turnos.mapper.js';
 
 /**
  * Registra un nuevo turno.
@@ -24,6 +25,55 @@ export const create = async (data) => {
   ]);
 
   return result.insertId;
+};
+
+/**
+ * Obtiene los turnos de un médico.
+ * @param {number} idMedico
+ * @returns {Promise<Object[]>}
+ */
+export const findByMedicoId = async (idMedico) => {
+  const query = `
+    SELECT 
+      tr.*, 
+      u.apellido AS paciente_apellido, 
+      u.nombres AS paciente_nombres, 
+      u.email AS paciente_email, 
+      os.nombre AS obra_social_nombre
+    FROM turnos_reservas tr
+    JOIN pacientes p ON tr.id_paciente = p.id_paciente
+    JOIN usuarios u ON p.id_usuario = u.id_usuario
+    JOIN obras_sociales os ON tr.id_obra_social = os.id_obra_social
+    WHERE tr.id_medico = ? AND tr.activo = ?
+    ORDER BY tr.fecha_hora DESC
+  `;
+  const [rows] = await pool.execute(query, [idMedico, DB_STATUS.ACTIVE]);
+  return turnosMapper.toDTOs(rows, { omitirMedico: true });
+};
+
+/**
+ * Obtiene los turnos de un paciente.
+ * @param {number} idPaciente
+ * @returns {Promise<Object[]>}
+ */
+export const findByPacienteId = async (idPaciente) => {
+  const query = `
+    SELECT 
+      tr.*, 
+      u.apellido AS medico_apellido, 
+      u.nombres AS medico_nombres, 
+      e.nombre AS especialidad, 
+      os.nombre AS obra_social_nombre
+    FROM turnos_reservas tr
+    JOIN medicos m ON tr.id_medico = m.id_medico
+    JOIN usuarios u ON m.id_usuario = u.id_usuario
+    JOIN especialidades e ON m.id_especialidad = e.id_especialidad
+    JOIN obras_sociales os ON tr.id_obra_social = os.id_obra_social
+    WHERE tr.id_paciente = ? AND tr.activo = ?
+    ORDER BY tr.fecha_hora DESC
+  `;
+  const [rows] = await pool.execute(query, [idPaciente, DB_STATUS.ACTIVE]);
+  return turnosMapper.toDTOs(rows, { omitirPaciente: true });
 };
 
 /**

--- a/tp-final-integrador/src/database/turnos.js
+++ b/tp-final-integrador/src/database/turnos.js
@@ -105,3 +105,34 @@ export const existsByMedicoAndFechaHora = async (idMedico, fechaHora) => {
   const [rows] = await pool.execute(query, [idMedico, fechaHora, DB_STATUS.ACTIVE]);
   return rows.length > 0;
 };
+
+/**
+ * Busca un turno por su ID.
+ * @param {number} id
+ * @returns {Promise<Object|null>}
+ */
+export const findById = async (id) => {
+  const query = `
+    SELECT * FROM turnos_reservas
+    WHERE id_turno_reserva = ?
+  `;
+  const [rows] = await pool.execute(query, [id]);
+
+  if (rows.length === 0) return null;
+  return turnosMapper.toDTO(rows[0]);
+};
+
+/**
+ * Actualiza el estado de atención de un turno.
+ * @param {number} id
+ * @param {number} atendido - 1 para atendido, 0 para no atendido.
+ * @returns {Promise<void>}
+ */
+export const updateAtendido = async (id, atendido) => {
+  const query = `
+    UPDATE turnos_reservas
+    SET atendido = ?
+    WHERE id_turno_reserva = ?
+  `;
+  await pool.execute(query, [atendido, id]);
+};

--- a/tp-final-integrador/src/database/turnos.mapper.js
+++ b/tp-final-integrador/src/database/turnos.mapper.js
@@ -1,0 +1,44 @@
+/**
+ * Mapper para la entidad Turno.
+ */
+
+export const toDTO = (row, options = {}) => {
+  if (!row) return null;
+
+  const { omitirMedico = false, omitirPaciente = false } = options;
+
+  return {
+    id: row.id_turno_reserva,
+    fechaHora: row.fecha_hora,
+    valorTotal: row.valor_total ? Number(row.valor_total) : 0,
+    atendido: Boolean(row.atendido),
+    activo: row.activo,
+    medico:
+      !omitirMedico && (row.medico_apellido || row.id_medico)
+        ? {
+            id: row.id_medico,
+            apellido: row.medico_apellido,
+            nombres: row.medico_nombres,
+            especialidad: row.especialidad,
+          }
+        : undefined,
+    paciente:
+      !omitirPaciente && (row.paciente_apellido || row.id_paciente)
+        ? {
+            id: row.id_paciente,
+            apellido: row.paciente_apellido,
+            nombres: row.paciente_nombres,
+            email: row.paciente_email,
+          }
+        : undefined,
+    obraSocial:
+      row.obra_social_nombre || row.id_obra_social
+        ? {
+            id: row.id_obra_social,
+            nombre: row.obra_social_nombre,
+          }
+        : undefined,
+  };
+};
+
+export const toDTOs = (rows, options = {}) => rows.map((row) => toDTO(row, options));

--- a/tp-final-integrador/src/routes/turnos.routes.js
+++ b/tp-final-integrador/src/routes/turnos.routes.js
@@ -10,15 +10,19 @@ const turnosRouter = Router();
 
 /**
  * Rutas para el módulo de Turnos.
- * Solo el Administrador (Role 3) puede registrar turnos.
  */
 
 turnosRouter.use(authenticateJwt);
-turnosRouter.use(requireRole([ROLES.ADMIN]));
 
 turnosRouter
   .route('/')
-  .post(turnosValidator.validateRegistrarTurno, validateRequest, turnosController.registrarTurno)
-  .all(methodNotAllowedHandler(['POST']));
+  .get(requireRole([ROLES.MEDICO, ROLES.PACIENTE]), turnosController.listarTurnosPropios)
+  .post(
+    requireRole([ROLES.ADMIN]),
+    turnosValidator.validateRegistrarTurno,
+    validateRequest,
+    turnosController.registrarTurno,
+  )
+  .all(methodNotAllowedHandler(['GET', 'POST']));
 
 export default turnosRouter;

--- a/tp-final-integrador/src/routes/turnos.routes.js
+++ b/tp-final-integrador/src/routes/turnos.routes.js
@@ -25,4 +25,14 @@ turnosRouter
   )
   .all(methodNotAllowedHandler(['GET', 'POST']));
 
+turnosRouter
+  .route('/:id/atendido')
+  .patch(
+    requireRole([ROLES.MEDICO]),
+    turnosValidator.validateMarcarAtendido,
+    validateRequest,
+    turnosController.marcarComoAtendido,
+  )
+  .all(methodNotAllowedHandler(['PATCH']));
+
 export default turnosRouter;

--- a/tp-final-integrador/src/services/turnos.service.js
+++ b/tp-final-integrador/src/services/turnos.service.js
@@ -142,3 +142,40 @@ export const registrarTurno = async (data) => {
     activo: DB_STATUS.ACTIVE,
   };
 };
+
+/**
+ * Marca un turno como atendido.
+ * @param {number} idTurno
+ * @param {number} idUsuario - ID del usuario médico que realiza la acción.
+ * @returns {Promise<Object>} Datos del turno actualizado.
+ */
+export const marcarComoAtendido = async (idTurno, idUsuario) => {
+  const medico = await findActiveOrThrow(medicosModel.findByUserId, idUsuario, {
+    notFoundMessage: 'Perfil de médico no encontrado',
+    inactiveMessage: 'El médico solicitado no se encuentra activo',
+  });
+
+  const turno = await turnosModel.findById(idTurno);
+
+  if (!turno) {
+    throw new AppError(ERROR_CODES.NOT_FOUND, 'El turno solicitado no existe');
+  }
+
+  if (turno.medico.id !== medico.idMedico) {
+    throw new AppError(
+      ERROR_CODES.FORBIDDEN,
+      'No tiene permisos para marcar este turno como atendido',
+    );
+  }
+
+  if (turno.atendido) {
+    throw new AppError(ERROR_CODES.DUPLICATE_ENTRY, 'El turno ya ha sido marcado como atendido');
+  }
+
+  await turnosModel.updateAtendido(idTurno, 1);
+
+  return {
+    ...turno,
+    atendido: 1,
+  };
+};

--- a/tp-final-integrador/src/services/turnos.service.js
+++ b/tp-final-integrador/src/services/turnos.service.js
@@ -4,6 +4,35 @@ import * as pacientesModel from '../database/pacientes.js';
 import * as obrasSocialesModel from '../database/obras_sociales.js';
 import { AppError, ERROR_CODES } from '../helpers/errors.helper.js';
 import { DB_STATUS } from '../constants/common.constants.js';
+import { ROLES } from '../constants/roles.constants.js';
+
+/**
+ * Obtiene los turnos propios del usuario según su rol.
+ * @param {Object} usuario - El usuario autenticado (extraído de req.user).
+ * @returns {Promise<Object[]>} Lista de turnos.
+ */
+export const listarTurnosPropios = async (usuario) => {
+  if (usuario.rol === ROLES.MEDICO) {
+    const medico = await medicosModel.findByUserId(usuario.id);
+    if (!medico) {
+      throw new AppError(ERROR_CODES.NOT_FOUND, 'Perfil de médico no encontrado');
+    }
+    return await turnosModel.findByMedicoId(medico.idMedico);
+  }
+
+  if (usuario.rol === ROLES.PACIENTE) {
+    const paciente = await pacientesModel.findByUserId(usuario.id);
+    if (!paciente) {
+      throw new AppError(ERROR_CODES.NOT_FOUND, 'Perfil de paciente no encontrado');
+    }
+    return await turnosModel.findByPacienteId(paciente.idPaciente);
+  }
+
+  throw new AppError(
+    ERROR_CODES.FORBIDDEN,
+    'El rol del usuario no tiene permisos para esta acción',
+  );
+};
 
 /**
  * Registra un nuevo turno con cálculo de valor_total.

--- a/tp-final-integrador/src/services/turnos.service.js
+++ b/tp-final-integrador/src/services/turnos.service.js
@@ -7,24 +7,44 @@ import { DB_STATUS } from '../constants/common.constants.js';
 import { ROLES } from '../constants/roles.constants.js';
 
 /**
+ * Busca una entidad por ID y lanza un error si no existe o no está activa.
+ * @param {Function} findFn - Función async que recibe el ID y retorna la entidad o null.
+ * @param {*} id - El ID a buscar.
+ * @param {Object} messages - Mensajes de error personalizados.
+ * @param {string} messages.notFoundMessage - Mensaje cuando la entidad no existe.
+ * @param {string} messages.inactiveMessage - Mensaje cuando la entidad está inactiva.
+ * @returns {Promise<Object>} La entidad encontrada y activa.
+ */
+const findActiveOrThrow = async (findFn, id, { notFoundMessage, inactiveMessage }) => {
+  const entity = await findFn(id);
+  if (!entity) {
+    throw new AppError(ERROR_CODES.NOT_FOUND, notFoundMessage);
+  }
+  if (!entity.activo) {
+    throw new AppError(ERROR_CODES.VALIDATION_ERROR, inactiveMessage);
+  }
+  return entity;
+};
+
+/**
  * Obtiene los turnos propios del usuario según su rol.
  * @param {Object} usuario - El usuario autenticado (extraído de req.user).
  * @returns {Promise<Object[]>} Lista de turnos.
  */
 export const listarTurnosPropios = async (usuario) => {
   if (usuario.rol === ROLES.MEDICO) {
-    const medico = await medicosModel.findByUserId(usuario.id);
-    if (!medico) {
-      throw new AppError(ERROR_CODES.NOT_FOUND, 'Perfil de médico no encontrado');
-    }
+    const medico = await findActiveOrThrow(medicosModel.findByUserId, usuario.id, {
+      notFoundMessage: 'Perfil de médico no encontrado',
+      inactiveMessage: 'El médico solicitado no se encuentra activo',
+    });
     return await turnosModel.findByMedicoId(medico.idMedico);
   }
 
   if (usuario.rol === ROLES.PACIENTE) {
-    const paciente = await pacientesModel.findByUserId(usuario.id);
-    if (!paciente) {
-      throw new AppError(ERROR_CODES.NOT_FOUND, 'Perfil de paciente no encontrado');
-    }
+    const paciente = await findActiveOrThrow(pacientesModel.findByUserId, usuario.id, {
+      notFoundMessage: 'Perfil de paciente no encontrado',
+      inactiveMessage: 'El paciente solicitado no se encuentra activo',
+    });
     return await turnosModel.findByPacienteId(paciente.idPaciente);
   }
 
@@ -42,24 +62,15 @@ export const listarTurnosPropios = async (usuario) => {
 export const registrarTurno = async (data) => {
   const { idMedico, idPaciente, idObraSocial, fecha, hora } = data;
 
-  const medico = await medicosModel.findById(idMedico);
-  if (!medico) {
-    throw new AppError(ERROR_CODES.NOT_FOUND, 'El médico solicitado no existe');
-  }
-  if (!medico.activo) {
-    throw new AppError(ERROR_CODES.VALIDATION_ERROR, 'El médico solicitado no se encuentra activo');
-  }
+  const medico = await findActiveOrThrow(medicosModel.findById, idMedico, {
+    notFoundMessage: 'El médico solicitado no existe',
+    inactiveMessage: 'El médico solicitado no se encuentra activo',
+  });
 
-  const paciente = await pacientesModel.findById(idPaciente);
-  if (!paciente) {
-    throw new AppError(ERROR_CODES.NOT_FOUND, 'El paciente solicitado no existe');
-  }
-  if (!paciente.activo) {
-    throw new AppError(
-      ERROR_CODES.VALIDATION_ERROR,
-      'El paciente solicitado no se encuentra activo',
-    );
-  }
+  const paciente = await findActiveOrThrow(pacientesModel.findById, idPaciente, {
+    notFoundMessage: 'El paciente solicitado no existe',
+    inactiveMessage: 'El paciente solicitado no se encuentra activo',
+  });
 
   if (paciente.idObraSocial !== idObraSocial) {
     throw new AppError(
@@ -68,16 +79,14 @@ export const registrarTurno = async (data) => {
     );
   }
 
-  const obraSocial = await obrasSocialesModel.findById(idObraSocial, false);
-  if (!obraSocial) {
-    throw new AppError(ERROR_CODES.NOT_FOUND, 'La obra social solicitada no existe');
-  }
-  if (!obraSocial.activo) {
-    throw new AppError(
-      ERROR_CODES.VALIDATION_ERROR,
-      'La obra social solicitada no se encuentra activa',
-    );
-  }
+  const obraSocial = await findActiveOrThrow(
+    (id) => obrasSocialesModel.findById(id, false),
+    idObraSocial,
+    {
+      notFoundMessage: 'La obra social solicitada no existe',
+      inactiveMessage: 'La obra social solicitada no se encuentra activa',
+    },
+  );
 
   if (!obraSocial.esParticular) {
     const aceptaObraSocial = await medicosModel.acceptsObraSocial(idMedico, idObraSocial);

--- a/tp-final-integrador/src/validators/turnos.validator.js
+++ b/tp-final-integrador/src/validators/turnos.validator.js
@@ -1,4 +1,4 @@
-import { body } from 'express-validator';
+import { body, param } from 'express-validator';
 
 /**
  * Validaciones para el módulo de Turnos
@@ -46,4 +46,13 @@ export const validateRegistrarTurno = [
     .withMessage('La hora es requerida')
     .matches(/^([01]\d|2[0-3]):([0-5]\d)$/)
     .withMessage('La hora debe tener un formato válido (HH:mm)'),
+];
+
+export const validateMarcarAtendido = [
+  param('id')
+    .notEmpty()
+    .withMessage('El ID del turno es requerido')
+    .isInt({ min: 1 })
+    .withMessage('El ID del turno debe ser un número entero positivo')
+    .toInt(),
 ];

--- a/tp-final-integrador/tests/modules/turnos.list.test.js
+++ b/tp-final-integrador/tests/modules/turnos.list.test.js
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll } from 'vitest';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { app } from '../../src/app.js';
+import { pool } from '../../src/config/db.js';
+import { setupTestDB } from '../setup/db.js';
+import { ROLES } from '../../src/constants/roles.constants.js';
+
+describe('Turnos List - Integration Tests', () => {
+  let adminToken;
+  let patientToken;
+  let doctorToken;
+  const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+
+  beforeEach(async () => {
+    await setupTestDB();
+
+    // 1. Especialidad
+    await pool.execute(
+      'INSERT INTO especialidades (id_especialidad, nombre, activo) VALUES (?, ?, ?)',
+      [1, 'PEDIATRÍA', 1],
+    );
+
+    // 2. Obra Social
+    await pool.execute(
+      'INSERT INTO obras_sociales (id_obra_social, nombre, descripcion, porcentaje_descuento, es_particular, activo) VALUES (?, ?, ?, ?, ?, ?)',
+      [1, 'OSDE', 'Plan 210', 0.1, 0, 1],
+    );
+
+    // 3. Usuarios
+    await pool.execute(
+      'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      [1, '11111111', 'Admin', 'Root', 'admin@test.com', 'hash', '', ROLES.ADMIN, 1],
+    );
+    await pool.execute(
+      'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      [2, '22222222', 'Medico', 'Doc', 'medico@test.com', 'hash', '', ROLES.MEDICO, 1],
+    );
+    await pool.execute(
+      'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      [3, '33333333', 'Paciente', 'User', 'paciente@test.com', 'hash', '', ROLES.PACIENTE, 1],
+    );
+
+    // 4. Medico
+    await pool.execute(
+      'INSERT INTO medicos (id_medico, id_usuario, id_especialidad, matricula, valor_consulta) VALUES (?, ?, ?, ?, ?)',
+      [1, 2, 1, 2000, 5000.0],
+    );
+
+    // 5. Paciente
+    await pool.execute(
+      'INSERT INTO pacientes (id_paciente, id_usuario, id_obra_social) VALUES (?, ?, ?)',
+      [1, 3, 1],
+    );
+
+    // 6. Turno
+    await pool.execute(
+      'INSERT INTO turnos_reservas (id_medico, id_paciente, id_obra_social, fecha_hora, valor_total, atendido, activo) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      [1, 1, 1, '2026-07-15 14:30:00', 4500.0, 0, 1],
+    );
+
+    // Tokens
+    adminToken = jwt.sign({ id: 1, rol: ROLES.ADMIN, documento: '11111111' }, JWT_SECRET);
+    doctorToken = jwt.sign({ id: 2, rol: ROLES.MEDICO, documento: '22222222' }, JWT_SECRET);
+    patientToken = jwt.sign({ id: 3, rol: ROLES.PACIENTE, documento: '33333333' }, JWT_SECRET);
+  });
+
+  afterEach(async () => {
+    await setupTestDB(); // setupTestDB ya limpia la base
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  describe('GET /api/v1/turnos', () => {
+    it('Doctor should see their own turnos', async () => {
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${doctorToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(Array.isArray(response.body.data)).toBe(true);
+      expect(response.body.data.length).toBe(1);
+      expect(response.body.data[0].paciente).toBeDefined();
+      expect(response.body.data[0].paciente.id).toBe(1);
+      expect(response.body.data[0].paciente.apellido).toBe('Paciente');
+      expect(response.body.data[0].medico).toBeUndefined();
+    });
+
+    it('Patient should see their own turnos', async () => {
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${patientToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(Array.isArray(response.body.data)).toBe(true);
+      expect(response.body.data.length).toBe(1);
+      expect(response.body.data[0].medico).toBeDefined();
+      expect(response.body.data[0].medico.id).toBe(1);
+      expect(response.body.data[0].medico.apellido).toBe('Medico');
+      expect(response.body.data[0].paciente).toBeUndefined();
+    });
+
+    it('Admin should be forbidden from listing turnos (not a doctor or patient)', async () => {
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(response.status).toBe(403);
+    });
+
+    it('Doctor without profile should return 404', async () => {
+      // Create user with doctor role but no medicos entry
+      await pool.execute(
+        'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        [4, '44444444', 'Ghost', 'Doc', 'ghost@test.com', 'hash', '', ROLES.MEDICO, 1],
+      );
+      const ghostToken = jwt.sign({ id: 4, rol: ROLES.MEDICO, documento: '44444444' }, JWT_SECRET);
+
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${ghostToken}`);
+
+      expect(response.status).toBe(404);
+      expect(response.body.error.message).toBe('Perfil de médico no encontrado');
+    });
+
+    it('Patient without profile should return 404', async () => {
+      // Create user with patient role but no pacientes entry
+      await pool.execute(
+        'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        [5, '55555555', 'Ghost', 'Patient', 'ghostpatient@test.com', 'hash', '', ROLES.PACIENTE, 1],
+      );
+      const ghostToken = jwt.sign(
+        { id: 5, rol: ROLES.PACIENTE, documento: '55555555' },
+        JWT_SECRET,
+      );
+
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${ghostToken}`);
+
+      expect(response.status).toBe(404);
+      expect(response.body.error.message).toBe('Perfil de paciente no encontrado');
+    });
+
+    it('Should not list inactive turnos', async () => {
+      // Create an inactive turno
+      await pool.execute(
+        'INSERT INTO turnos_reservas (id_medico, id_paciente, id_obra_social, fecha_hora, valor_total, atendido, activo) VALUES (?, ?, ?, ?, ?, ?, ?)',
+        [1, 1, 1, '2026-07-16 10:00:00', 4500.0, 0, 0], // Activo = 0
+      );
+
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${patientToken}`);
+
+      expect(response.status).toBe(200);
+      // Should only see the active one from beforeEach
+      expect(response.body.data.length).toBe(1);
+      expect(response.body.data[0].fechaHora).not.toContain('2026-07-16 10:00:00');
+    });
+
+    it('Should return turnos ordered by date descending', async () => {
+      // Add a second turno for the same patient, but EARLIER than the one in beforeEach (2026-07-15 14:30:00)
+      await pool.execute(
+        'INSERT INTO turnos_reservas (id_medico, id_paciente, id_obra_social, fecha_hora, valor_total, atendido, activo) VALUES (?, ?, ?, ?, ?, ?, ?)',
+        [1, 1, 1, '2026-07-10 09:00:00', 4500.0, 0, 1],
+      );
+
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${patientToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.length).toBe(2);
+
+      // The first one should be the LATEST (July 15th)
+      const firstDate = new Date(response.body.data[0].fechaHora);
+      const secondDate = new Date(response.body.data[1].fechaHora);
+
+      expect(firstDate.getTime()).toBeGreaterThan(secondDate.getTime());
+      expect(response.body.data[0].fechaHora).toContain('2026-07-15');
+      expect(response.body.data[1].fechaHora).toContain('2026-07-10');
+    });
+
+    it('Should return an empty array if no turnos found', async () => {
+      // Create a new patient without turnos
+      await pool.execute(
+        'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        [6, '66666666', 'New', 'Patient', 'new@test.com', 'hash', '', ROLES.PACIENTE, 1],
+      );
+      await pool.execute(
+        'INSERT INTO pacientes (id_paciente, id_usuario, id_obra_social) VALUES (?, ?, ?)',
+        [2, 6, 1],
+      );
+      const newToken = jwt.sign({ id: 6, rol: ROLES.PACIENTE, documento: '66666666' }, JWT_SECRET);
+
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${newToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data).toEqual([]);
+    });
+
+    it('Should return 401 if no token is provided', async () => {
+      const response = await request(app).get('/api/v1/turnos');
+      expect(response.status).toBe(401);
+    });
+  });
+});

--- a/tp-final-integrador/tests/modules/turnos.service.test.js
+++ b/tp-final-integrador/tests/modules/turnos.service.test.js
@@ -4,20 +4,25 @@ import * as turnosModel from '../../src/database/turnos.js';
 import * as medicosModel from '../../src/database/medicos.js';
 import * as pacientesModel from '../../src/database/pacientes.js';
 import * as obrasSocialesModel from '../../src/database/obras_sociales.js';
+import { ROLES } from '../../src/constants/roles.constants.js';
 
 vi.mock('../../src/database/turnos.js', () => ({
   create: vi.fn(),
   checkPatientOverlap: vi.fn(),
   existsByMedicoAndFechaHora: vi.fn(),
+  findByMedicoId: vi.fn(),
+  findByPacienteId: vi.fn(),
 }));
 
 vi.mock('../../src/database/medicos.js', () => ({
   findById: vi.fn(),
+  findByUserId: vi.fn(),
   acceptsObraSocial: vi.fn(),
 }));
 
 vi.mock('../../src/database/pacientes.js', () => ({
   findById: vi.fn(),
+  findByUserId: vi.fn(),
 }));
 
 vi.mock('../../src/database/obras_sociales.js', () => ({
@@ -30,6 +35,65 @@ describe('Turnos Service - Unit Tests', () => {
     medicosModel.acceptsObraSocial.mockResolvedValue(true);
     turnosModel.checkPatientOverlap.mockResolvedValue(false);
     turnosModel.existsByMedicoAndFechaHora.mockResolvedValue(false);
+  });
+
+  describe('listarTurnosPropios()', () => {
+    it('debería retornar los turnos del médico cuando el rol es MEDICO', async () => {
+      const mockMedico = { idMedico: 1 };
+      const mockTurnos = [{ id: 1, fecha: '2026-07-15' }];
+      medicosModel.findByUserId.mockResolvedValue(mockMedico);
+      turnosModel.findByMedicoId.mockResolvedValue(mockTurnos);
+
+      const result = await turnosService.listarTurnosPropios({ id: 2, rol: ROLES.MEDICO });
+
+      expect(medicosModel.findByUserId).toHaveBeenCalledWith(2);
+      expect(turnosModel.findByMedicoId).toHaveBeenCalledWith(1);
+      expect(result).toEqual(mockTurnos);
+    });
+
+    it('debería lanzar NOT_FOUND si el médico no tiene perfil', async () => {
+      medicosModel.findByUserId.mockResolvedValue(null);
+
+      await expect(
+        turnosService.listarTurnosPropios({ id: 99, rol: ROLES.MEDICO }),
+      ).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+        message: 'Perfil de médico no encontrado',
+      });
+    });
+
+    it('debería retornar los turnos del paciente cuando el rol es PACIENTE', async () => {
+      const mockPaciente = { idPaciente: 5 };
+      const mockTurnos = [{ id: 2, fecha: '2026-08-10' }];
+      pacientesModel.findByUserId.mockResolvedValue(mockPaciente);
+      turnosModel.findByPacienteId.mockResolvedValue(mockTurnos);
+
+      const result = await turnosService.listarTurnosPropios({ id: 3, rol: ROLES.PACIENTE });
+
+      expect(pacientesModel.findByUserId).toHaveBeenCalledWith(3);
+      expect(turnosModel.findByPacienteId).toHaveBeenCalledWith(5);
+      expect(result).toEqual(mockTurnos);
+    });
+
+    it('debería lanzar NOT_FOUND si el paciente no tiene perfil', async () => {
+      pacientesModel.findByUserId.mockResolvedValue(null);
+
+      await expect(
+        turnosService.listarTurnosPropios({ id: 99, rol: ROLES.PACIENTE }),
+      ).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+        message: 'Perfil de paciente no encontrado',
+      });
+    });
+
+    it('debería lanzar FORBIDDEN si el rol no es médico ni paciente', async () => {
+      await expect(
+        turnosService.listarTurnosPropios({ id: 1, rol: 'admin' }),
+      ).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+        message: 'El rol del usuario no tiene permisos para esta acción',
+      });
+    });
   });
 
   describe('registrarTurno() - Calculation Logic', () => {

--- a/tp-final-integrador/tests/modules/turnos.service.test.js
+++ b/tp-final-integrador/tests/modules/turnos.service.test.js
@@ -12,6 +12,8 @@ vi.mock('../../src/database/turnos.js', () => ({
   existsByMedicoAndFechaHora: vi.fn(),
   findByMedicoId: vi.fn(),
   findByPacienteId: vi.fn(),
+  findById: vi.fn(),
+  updateAtendido: vi.fn(),
 }));
 
 vi.mock('../../src/database/medicos.js', () => ({
@@ -39,7 +41,7 @@ describe('Turnos Service - Unit Tests', () => {
 
   describe('listarTurnosPropios()', () => {
     it('debería retornar los turnos del médico cuando el rol es MEDICO', async () => {
-      const mockMedico = { idMedico: 1 };
+      const mockMedico = { idMedico: 1, activo: true };
       const mockTurnos = [{ id: 1, fecha: '2026-07-15' }];
       medicosModel.findByUserId.mockResolvedValue(mockMedico);
       turnosModel.findByMedicoId.mockResolvedValue(mockTurnos);
@@ -63,7 +65,7 @@ describe('Turnos Service - Unit Tests', () => {
     });
 
     it('debería retornar los turnos del paciente cuando el rol es PACIENTE', async () => {
-      const mockPaciente = { idPaciente: 5 };
+      const mockPaciente = { idPaciente: 5, activo: true };
       const mockTurnos = [{ id: 2, fecha: '2026-08-10' }];
       pacientesModel.findByUserId.mockResolvedValue(mockPaciente);
       turnosModel.findByPacienteId.mockResolvedValue(mockTurnos);
@@ -342,6 +344,61 @@ describe('Turnos Service - Unit Tests', () => {
       await expect(turnosService.registrarTurno(data)).rejects.toThrow(
         'El paciente ya tiene un turno reservado para la misma fecha y hora',
       );
+    });
+  });
+
+  describe('marcarComoAtendido()', () => {
+    it('debería marcar un turno como atendido exitosamente', async () => {
+      const mockMedico = { idMedico: 10, activo: true };
+      const mockTurno = { id: 5, medico: { id: 10 }, atendido: false };
+
+      medicosModel.findByUserId.mockResolvedValue(mockMedico);
+      turnosModel.findById.mockResolvedValue(mockTurno);
+      turnosModel.updateAtendido.mockResolvedValue();
+
+      const result = await turnosService.marcarComoAtendido(5, 1);
+
+      expect(medicosModel.findByUserId).toHaveBeenCalledWith(1);
+      expect(turnosModel.findById).toHaveBeenCalledWith(5);
+      expect(turnosModel.updateAtendido).toHaveBeenCalledWith(5, 1);
+      expect(result.atendido).toBe(1);
+    });
+
+    it('debería lanzar FORBIDDEN si el turno no pertenece al médico', async () => {
+      const mockMedico = { idMedico: 10, activo: true };
+      const mockTurno = { id: 5, medico: { id: 11 }, atendido: false };
+
+      medicosModel.findByUserId.mockResolvedValue(mockMedico);
+      turnosModel.findById.mockResolvedValue(mockTurno);
+
+      await expect(turnosService.marcarComoAtendido(5, 1)).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+        message: 'No tiene permisos para marcar este turno como atendido',
+      });
+    });
+
+    it('debería lanzar DUPLICATE_ENTRY si el turno ya fue atendido', async () => {
+      const mockMedico = { idMedico: 10, activo: true };
+      const mockTurno = { id: 5, medico: { id: 10 }, atendido: true };
+
+      medicosModel.findByUserId.mockResolvedValue(mockMedico);
+      turnosModel.findById.mockResolvedValue(mockTurno);
+
+      await expect(turnosService.marcarComoAtendido(5, 1)).rejects.toMatchObject({
+        code: 'DUPLICATE_ENTRY',
+        message: 'El turno ya ha sido marcado como atendido',
+      });
+    });
+
+    it('debería lanzar NOT_FOUND si el turno no existe', async () => {
+      const mockMedico = { idMedico: 10, activo: true };
+      medicosModel.findByUserId.mockResolvedValue(mockMedico);
+      turnosModel.findById.mockResolvedValue(null);
+
+      await expect(turnosService.marcarComoAtendido(5, 1)).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+        message: 'El turno solicitado no existe',
+      });
     });
   });
 });

--- a/tp-final-integrador/tests/modules/turnos.test.js
+++ b/tp-final-integrador/tests/modules/turnos.test.js
@@ -9,6 +9,8 @@ import { ROLES } from '../../src/constants/roles.constants.js';
 describe('Turnos - Integration Tests', () => {
   let adminToken;
   let patientToken;
+  let medicoToken;
+  let otherMedicoToken;
   const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 
   beforeEach(async () => {
@@ -62,6 +64,18 @@ describe('Turnos - Integration Tests', () => {
     // Generar tokens
     adminToken = jwt.sign({ id: 8, rol: ROLES.ADMIN, documento: '51000111' }, JWT_SECRET);
     patientToken = jwt.sign({ id: 3, rol: ROLES.PACIENTE, documento: '33333333' }, JWT_SECRET);
+    medicoToken = jwt.sign({ id: 2, rol: ROLES.MEDICO, documento: '22222222' }, JWT_SECRET);
+
+    // Otro médico para probar pertenencia
+    await pool.execute(
+      'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      [10, '10101010', 'Other', 'Medico', 'other@test.com', 'hash', '', ROLES.MEDICO, 1],
+    );
+    await pool.execute(
+      'INSERT INTO medicos (id_medico, id_usuario, id_especialidad, matricula, valor_consulta) VALUES (?, ?, ?, ?, ?)',
+      [2, 10, 1, 3000, 6000.0],
+    );
+    otherMedicoToken = jwt.sign({ id: 10, rol: ROLES.MEDICO, documento: '10101010' }, JWT_SECRET);
   });
 
   afterAll(async () => {
@@ -356,6 +370,78 @@ describe('Turnos - Integration Tests', () => {
 
       expect(response.status).toBe(422);
       expect(response.body.error.code).toBe('VALIDATION_ERROR');
+    });
+  });
+
+  describe('PATCH /api/v1/turnos/:id/atendido', () => {
+    let turnoId;
+
+    beforeEach(async () => {
+      // Crear un turno para las pruebas
+      const [result] = await pool.execute(
+        'INSERT INTO turnos_reservas (id_medico, id_paciente, id_obra_social, fecha_hora, valor_total, atendido, activo) VALUES (?, ?, ?, ?, ?, ?, ?)',
+        [1, 1, 1, '2026-07-15 14:30:00', 4500.0, 0, 1],
+      );
+      turnoId = result.insertId;
+    });
+
+    it('Scenario 1: Doctor marks their own appointment as attended (200)', async () => {
+      const response = await request(app)
+        .patch(`/api/v1/turnos/${turnoId}/atendido`)
+        .set('Authorization', `Bearer ${medicoToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.atendido).toBe(1);
+    });
+
+    it('Scenario 2: Unauthorized role (Patient) (403)', async () => {
+      const response = await request(app)
+        .patch(`/api/v1/turnos/${turnoId}/atendido`)
+        .set('Authorization', `Bearer ${patientToken}`);
+
+      expect(response.status).toBe(403);
+    });
+
+    it('Scenario 3: Ownership failure (403)', async () => {
+      const response = await request(app)
+        .patch(`/api/v1/turnos/${turnoId}/atendido`)
+        .set('Authorization', `Bearer ${otherMedicoToken}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body.error.message).toBe(
+        'No tiene permisos para marcar este turno como atendido',
+      );
+    });
+
+    it('Scenario 4: Conflict - Already attended (409)', async () => {
+      // Marcar como atendido primero
+      await pool.execute('UPDATE turnos_reservas SET atendido = 1 WHERE id_turno_reserva = ?', [
+        turnoId,
+      ]);
+
+      const response = await request(app)
+        .patch(`/api/v1/turnos/${turnoId}/atendido`)
+        .set('Authorization', `Bearer ${medicoToken}`);
+
+      expect(response.status).toBe(409);
+      expect(response.body.error.message).toBe('El turno ya ha sido marcado como atendido');
+    });
+
+    it('Scenario 5: Not found (404)', async () => {
+      const response = await request(app)
+        .patch('/api/v1/turnos/9999/atendido')
+        .set('Authorization', `Bearer ${medicoToken}`);
+
+      expect(response.status).toBe(404);
+    });
+
+    it('Scenario 6: Invalid ID format (422)', async () => {
+      const response = await request(app)
+        .patch('/api/v1/turnos/abc/atendido')
+        .set('Authorization', `Bearer ${medicoToken}`);
+
+      expect(response.status).toBe(422);
     });
   });
 });

--- a/tp-final-integrador/tests/setup/db.js
+++ b/tp-final-integrador/tests/setup/db.js
@@ -13,13 +13,13 @@ export const clearDatabase = async () => {
   try {
     await pool.execute('SET FOREIGN_KEY_CHECKS = 0');
 
-    // Lista de tablas a limpiar (en orden de dependencia si fuera necesario, aunque con checks en 0 no importa tanto)
+    // Lista de tablas a limpiar
     const tables = [
+      'especialidades',
       'turnos_reservas',
       'medicos_obras_sociales',
       'pacientes',
       'medicos',
-      'especialidades',
       'obras_sociales',
       'usuarios',
     ];


### PR DESCRIPTION
Closes #69

### Tipo de PR
- [x] Nueva funcionalidad (New feature)


### Resumen
- Implementación del endpoint `PATCH /api/v1/turnos/:id/atendido` que permite a los médicos marcar sus turnos como atendidos.
- Validación de propiedad: un médico solo puede modificar turnos que tiene asignados.
- Manejo de conflictos (409) si el turno ya fue atendido y validación de turnos inactivos (404/422).

### Tabla de Cambios
| Archivo | Cambio |
|------|--------|
| `src/database/turnos.js` | Incorporación de los métodos `findById` y `updateAtendido`. |
| `src/validators/turnos.validator.js` | Regla de validación `validateMarcarAtendido` para el ID de turno. |
| `src/services/turnos.service.js` | Lógica de negocio en `marcarComoAtendido` y validación de propiedad y estado del turno. |
| `src/controllers/turnos.controller.js` | Handler de controlador para el endpoint. |
| `src/routes/turnos.routes.js` | Ruta de PATCH `/:id/atendido` con middleware de rol médico y JWT. |
| `docs/ENDPOINTS.md` | Registro y descripción del nuevo endpoint. |
| `bruno-collection/turnos/marcar-atendido.bru` | Solicitud y tests Bruno correspondientes. |
| `tests/modules/turnos.service.test.js` | Tests unitarios de lógica en la capa de servicios. |
| `tests/modules/turnos.test.js` | Pruebas de integración robustas (200, 403, 409, 422, 404). |


