### PR TITLE
feat(turnos): permitir registro de turnos a pacientes con resolución de identidad

### DIFF
--- a/prog3_turnos.sql
+++ b/prog3_turnos.sql
@@ -26,7 +26,7 @@ DELIMITER $$
 -- Procedimientos
 --
 CREATE DEFINER=`root`@`localhost` PROCEDURE `especialidades_x_turnos` ()   select count(e.id_especialidad) as cant_esp, e.nombre
-from turnos_reservas as tr 
+from turnos_reservas as tr
 inner join medicos as m on m.id_medico = tr.id_medico
 inner join especialidades as e on e.id_especialidad = m.id_especialidad
 GROUP by e.nombre
@@ -149,7 +149,9 @@ CREATE TABLE `pacientes` (
 INSERT INTO `pacientes` (`id_paciente`, `id_usuario`, `id_obra_social`) VALUES
 (1, 5, 1),
 (2, 6, 2),
-(3, 7, 3);
+(3, 7, 3),
+(4, 9, 1);
+
 
 -- --------------------------------------------------------
 
@@ -211,7 +213,9 @@ INSERT INTO `usuarios` (`id_usuario`, `documento`, `apellido`, `nombres`, `email
 (6, '41000112', 'Hunk', 'Lorena', 'hunlor@correo.com', '464db19217fabdaabc5add321054f39216d03edfef2efaf8c6769485415b7f25', '', 2, 1),
 (7, '41000113', 'Aguirre', 'Brian', 'agubri@correo.com', '2dfa174ae2688ec55d00f57c5a0a7783ba1f0e2981ab7df9f1cf933686c15274', '', 2, 1),
 (8, '51000111', 'Fernandez', 'Benito', 'ferben@correo.com', 'f127f4e9e4248f77eaa446ea9bff721e3e79eedf114ba6e1cfc633853ef07b4c', '', 3, 1),
-(10, '51000112', 'Gomez', 'Silvia', 'gomsil@correo.com', '601de117008d80e65ffad05dce97462d8f1b1e9aad6d68cf2b289703b8366b52', '', 3, 1);
+(10, '51000112', 'Gomez', 'Silvia', 'gomsil@correo.com', '76a8c23df7d396e6ff724af4263a4f1cb3f9858e1c29c449ac1153b34020bd26', '', 3, 1),
+(9, '41000114', 'Perez', 'Carlos', 'carlosperez@correo.com', 'bbe8be0ee37e9f1ce1cd25893151b35b6537ff607beca72e7b19814d2c7196c2', '', 2, 1);
+
 
 -- --------------------------------------------------------
 

--- a/prog3_turnos_modif.sql
+++ b/prog3_turnos_modif.sql
@@ -26,7 +26,7 @@ DELIMITER $$
 -- Procedimientos
 --
 CREATE DEFINER=`sql10823200`@`ec2-52-8-112-233.us-west-1.compute.amazonaws.com` PROCEDURE `especialidades_x_turnos` ()   select count(e.id_especialidad) as cant_esp, e.nombre
-from turnos_reservas as tr 
+from turnos_reservas as tr
 inner join medicos as m on m.id_medico = tr.id_medico
 inner join especialidades as e on e.id_especialidad = m.id_especialidad
 GROUP by e.nombre
@@ -149,7 +149,9 @@ CREATE TABLE `pacientes` (
 INSERT INTO `pacientes` (`id_paciente`, `id_usuario`, `id_obra_social`) VALUES
 (1, 5, 1),
 (2, 6, 2),
-(3, 7, 3);
+(3, 7, 3),
+(4, 9, 1);
+
 
 -- --------------------------------------------------------
 
@@ -211,7 +213,9 @@ INSERT INTO `usuarios` (`id_usuario`, `documento`, `apellido`, `nombres`, `email
 (6, '41000112', 'Hunk', 'Lorena', 'hunlor@correo.com', '464db19217fabdaabc5add321054f39216d03edfef2efaf8c6769485415b7f25', '', 2, 1),
 (7, '41000113', 'Aguirre', 'Brian', 'agubri@correo.com', '2dfa174ae2688ec55d00f57c5a0a7783ba1f0e2981ab7df9f1cf933686c15274', '', 2, 1),
 (8, '51000111', 'Fernandez', 'Benito', 'ferben@correo.com', 'f127f4e9e4248f77eaa446ea9bff721e3e79eedf114ba6e1cfc633853ef07b4c', '', 3, 1),
-(10, '51000112', 'Gomez', 'Silvia', 'gomsil@correo.com', '601de117008d80e65ffad05dce97462d8f1b1e9aad6d68cf2b289703b8366b52', '', 3, 1);
+(10, '51000112', 'Gomez', 'Silvia', 'gomsil@correo.com', '76a8c23df7d396e6ff724af4263a4f1cb3f9858e1c29c449ac1153b34020bd26', '', 3, 1),
+(9, '41000114', 'Perez', 'Carlos', 'carlosperez@correo.com', 'bbe8be0ee37e9f1ce1cd25893151b35b6537ff607beca72e7b19814d2c7196c2', '', 2, 1);
+
 
 -- --------------------------------------------------------
 

--- a/tp-final-integrador/bruno-collection/auth/login.bru
+++ b/tp-final-integrador/bruno-collection/auth/login.bru
@@ -17,8 +17,8 @@ headers {
 
 body:json {
   {
-    "email": "gomsil@correo.com",
-    "contrasenia": "gomsil"
+    "email": "lopjac@correo.com",
+    "contrasenia": "lopjac"
   }
 }
 

--- a/tp-final-integrador/bruno-collection/auth/login.bru
+++ b/tp-final-integrador/bruno-collection/auth/login.bru
@@ -17,23 +17,16 @@ headers {
 
 body:json {
   {
-    "email": "ferben@correo.com",
-    "contrasenia": "ferben"
+    "email": "gomsil@correo.com",
+    "contrasenia": "gomsil"
   }
 }
 
 script:post-response {
-  let body = res.body;
-  if (typeof body === 'string') {
-    try {
-      body = JSON.parse(body);
-    } catch (e) {}
-  }
-  const token = body && (body.token || (body.data && body.data.token));
-  if (token) {
-    bru.setEnvVar("authToken", token);
-    bru.setVar("authToken", token);
-  }
+  const {data} = res.getBody();
+    if (Boolean(data) === true && Boolean(data.token) === true) {
+      bru.setVar("authToken", data.token);
+    }
 }
 
 docs {

--- a/tp-final-integrador/bruno-collection/collection.bru
+++ b/tp-final-integrador/bruno-collection/collection.bru
@@ -1,3 +1,11 @@
 meta {
   name: Clínica Médica API
 }
+
+auth {
+  mode: bearer
+}
+
+auth:bearer {
+  token: {{authToken}}
+}

--- a/tp-final-integrador/bruno-collection/health/health-check.bru
+++ b/tp-final-integrador/bruno-collection/health/health-check.bru
@@ -6,7 +6,8 @@ meta {
 
 get {
   url: {{baseUrl}}/health
-  auth: none
+  auth: inherit
+  body: none
 }
 
 docs {

--- a/tp-final-integrador/bruno-collection/medicos/asociar-obras-sociales.bru
+++ b/tp-final-integrador/bruno-collection/medicos/asociar-obras-sociales.bru
@@ -21,7 +21,6 @@ body:json {
 }
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 docs {

--- a/tp-final-integrador/bruno-collection/obras-sociales/Get All (Actives and not actives).bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/Get All (Actives and not actives).bru
@@ -7,12 +7,11 @@ meta {
 get {
   url: {{baseUrl}}/obras-sociales?activo=all
   body: none
-  auth: none
+  auth: inherit
 }
 
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 params:query {

--- a/tp-final-integrador/bruno-collection/obras-sociales/Get All Actives.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/Get All Actives.bru
@@ -7,10 +7,9 @@ meta {
 get {
   url: {{baseUrl}}/obras-sociales
   body: none
-  auth: none
+  auth: inherit
 }
 
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }

--- a/tp-final-integrador/bruno-collection/obras-sociales/Get All c params.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/Get All c params.bru
@@ -7,7 +7,7 @@ meta {
 get {
   url: {{baseUrl}}/obras-sociales?limit=10&offset=0&order=nombre&asc=true&nombre=OSUNER
   body: none
-  auth: none
+  auth: inherit
 }
 
 params:query {
@@ -20,7 +20,6 @@ params:query {
 
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 script:pre-request {

--- a/tp-final-integrador/bruno-collection/obras-sociales/create.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/create.bru
@@ -7,13 +7,12 @@ meta {
 post {
   url: {{baseUrl}}/obras-sociales
   body: json
-  auth: none
+  auth: inherit
 }
 
 headers {
   Accept: application/json
   Content-Type: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 body:json {

--- a/tp-final-integrador/bruno-collection/obras-sociales/delete.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/delete.bru
@@ -7,12 +7,11 @@ meta {
 delete {
   url: {{baseUrl}}/obras-sociales/1
   body: none
-  auth: none
+  auth: inherit
 }
 
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 docs {

--- a/tp-final-integrador/bruno-collection/obras-sociales/get-by-id.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/get-by-id.bru
@@ -7,12 +7,11 @@ meta {
 get {
   url: {{baseUrl}}/obras-sociales/1
   body: none
-  auth: none
+  auth: inherit
 }
 
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 docs {

--- a/tp-final-integrador/bruno-collection/obras-sociales/update.bru
+++ b/tp-final-integrador/bruno-collection/obras-sociales/update.bru
@@ -7,13 +7,12 @@ meta {
 put {
   url: {{baseUrl}}/obras-sociales/1
   body: json
-  auth: none
+  auth: inherit
 }
 
 headers {
   Accept: application/json
   Content-Type: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 body:json {

--- a/tp-final-integrador/bruno-collection/turnos/error-fecha-pasada.bru
+++ b/tp-final-integrador/bruno-collection/turnos/error-fecha-pasada.bru
@@ -21,7 +21,6 @@ body:json {
 }
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 docs {

--- a/tp-final-integrador/bruno-collection/turnos/listar-propios.bru
+++ b/tp-final-integrador/bruno-collection/turnos/listar-propios.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Listar Turnos Propios
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/turnos
+  body: none
+  auth: inherit
+}
+
+headers {
+  Accept: application/json
+}
+
+docs {
+  Obtiene la lista de turnos propios del usuario autenticado.
+  
+  - Si el usuario es **Médico**, verá sus turnos con datos del paciente.
+  - Si el usuario es **Paciente**, verá sus turnos con datos del médico.
+  - Requiere un token válido en la variable de entorno `authToken`.
+}

--- a/tp-final-integrador/bruno-collection/turnos/marcar-atendido.bru
+++ b/tp-final-integrador/bruno-collection/turnos/marcar-atendido.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Marcar Turno como Atendido
+  type: http
+  seq: 5
+}
+
+patch {
+  url: {{baseUrl}}/turnos/:id/atendido
+  body: none
+  auth: inherit
+}
+
+params:path {
+  id: 1
+}
+
+headers {
+  Accept: application/json
+}
+
+docs {
+  Permite a un médico marcar uno de sus turnos asignados como atendido.
+  
+  - **Acceso**: Solo Médicos.
+  - **Validación**: Solo puede marcar turnos que le pertenecen.
+  - **Idempotencia**: Si el turno ya fue atendido, retorna un error 409 Conflict.
+}

--- a/tp-final-integrador/bruno-collection/turnos/registrar-como-paciente.bru
+++ b/tp-final-integrador/bruno-collection/turnos/registrar-como-paciente.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Registrar Turno (Como Paciente)
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/turnos
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "idMedico": 1,
+    "fecha": "2026-07-20",
+    "hora": "10:30"
+  }
+}
+
+headers {
+  Accept: application/json
+}
+
+docs {
+  Permite a un paciente autenticado registrar un turno para sí mismo.
+  
+  **Seguridad y Reglas de Negocio**:
+  - `idPaciente` e `idObraSocial` se resuelven automáticamente desde el perfil del paciente autenticado (`req.user.id`).
+  - No es necesario (ni se permite) pasar `idPaciente` ni `idObraSocial` en el cuerpo de la petición.
+  - El rol del usuario autenticado debe ser `PACIENTE`.
+}

--- a/tp-final-integrador/bruno-collection/turnos/registrar-obra-social.bru
+++ b/tp-final-integrador/bruno-collection/turnos/registrar-obra-social.bru
@@ -6,6 +6,7 @@ meta {
 
 post {
   url: {{baseUrl}}/turnos
+  auth: inherit
   body: json
 }
 
@@ -20,7 +21,6 @@ body:json {
 }
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 docs {

--- a/tp-final-integrador/bruno-collection/turnos/registrar-particular.bru
+++ b/tp-final-integrador/bruno-collection/turnos/registrar-particular.bru
@@ -6,6 +6,7 @@ meta {
 
 post {
   url: {{baseUrl}}/turnos
+  auth: inherit
   body: json
 }
 
@@ -20,7 +21,6 @@ body:json {
 }
 headers {
   Accept: application/json
-  Authorization: Bearer {{authToken}}
 }
 
 docs {

--- a/tp-final-integrador/docs/ENDPOINTS.md
+++ b/tp-final-integrador/docs/ENDPOINTS.md
@@ -45,6 +45,21 @@ Este documento detalla los endpoints disponibles en la API para facilitar las pr
 
 ---
 
+## 📅 Turnos (`/turnos`)
+
+| Método | Endpoint | Descripción | Acceso |
+| :--- | :--- | :--- | :--- |
+| `GET` | `/api/v1/turnos` | Listar turnos propios | Médico / Paciente |
+| `POST` | `/api/v1/turnos` | Registrar un nuevo turno | Admin |
+
+### Detalles de Turnos
+- El listado de turnos (`GET`) devuelve los turnos del usuario autenticado según su rol.
+- Si el usuario es **Médico**, el listado incluye datos del paciente y la obra social.
+- Si el usuario es **Paciente**, el listado incluye datos del médico, su especialidad y la obra social.
+- El registro de turnos (`POST`) calcula automáticamente el `valor_total` basándose en el valor de consulta del médico y el descuento de la obra social del paciente.
+
+---
+
 
 
 ---

--- a/tp-final-integrador/docs/ENDPOINTS.md
+++ b/tp-final-integrador/docs/ENDPOINTS.md
@@ -50,14 +50,17 @@ Este documento detalla los endpoints disponibles en la API para facilitar las pr
 | Método | Endpoint | Descripción | Acceso |
 | :--- | :--- | :--- | :--- |
 | `GET` | `/api/v1/turnos` | Listar turnos propios | Médico / Paciente |
-| `POST` | `/api/v1/turnos` | Registrar un nuevo turno | Admin |
+| `POST` | `/api/v1/turnos` | Registrar un nuevo turno | Admin / Paciente |
 | `PATCH` | `/api/v1/turnos/:id/atendido` | Marcar turno como atendido | Médico |
 
 ### Detalles de Turnos
 - El listado de turnos (`GET`) devuelve los turnos del usuario autenticado según su rol.
-- Si el usuario es **Médico**, el listado incluye datos del paciente y la obra social.
-- Si el usuario es **Paciente**, el listado incluye datos del médico, su especialidad y la obra social.
-- El registro de turnos (`POST`) calcula automáticamente el `valor_total` basándose en el valor de consulta del médico y el descuento de la obra social del paciente.
+  - Si el usuario es **Médico**, el listado incluye datos del paciente y la obra social.
+  - Si el usuario es **Paciente**, el listado incluye datos del médico, su especialidad y la obra social.
+- El registro de turnos (`POST`) funciona de la siguiente manera según el rol:
+  - **Administrador**: Debe pasar `idPaciente` e `idObraSocial` en el body para agendar el turno en nombre de cualquier paciente.
+  - **Paciente**: No debe enviar `idPaciente` ni `idObraSocial` en el body; el sistema los resuelve automáticamente de forma segura a partir de su perfil asociado.
+  - En ambos casos, se calcula automáticamente el `valor_total` basándose en el valor de consulta del médico y el descuento de la obra social aplicable.
 
 ---
 

--- a/tp-final-integrador/docs/ENDPOINTS.md
+++ b/tp-final-integrador/docs/ENDPOINTS.md
@@ -51,6 +51,7 @@ Este documento detalla los endpoints disponibles en la API para facilitar las pr
 | :--- | :--- | :--- | :--- |
 | `GET` | `/api/v1/turnos` | Listar turnos propios | Médico / Paciente |
 | `POST` | `/api/v1/turnos` | Registrar un nuevo turno | Admin |
+| `PATCH` | `/api/v1/turnos/:id/atendido` | Marcar turno como atendido | Médico |
 
 ### Detalles de Turnos
 - El listado de turnos (`GET`) devuelve los turnos del usuario autenticado según su rol.

--- a/tp-final-integrador/init/schema.sql
+++ b/tp-final-integrador/init/schema.sql
@@ -149,7 +149,9 @@ CREATE TABLE `pacientes` (
 INSERT INTO `pacientes` (`id_paciente`, `id_usuario`, `id_obra_social`) VALUES
 (1, 5, 1),
 (2, 6, 2),
-(3, 7, 3);
+(3, 7, 3),
+(4, 9, 1);
+
 
 -- --------------------------------------------------------
 
@@ -211,7 +213,9 @@ INSERT INTO `usuarios` (`id_usuario`, `documento`, `apellido`, `nombres`, `email
 (6, '41000112', 'Hunk', 'Lorena', 'hunlor@correo.com', '464db19217fabdaabc5add321054f39216d03edfef2efaf8c6769485415b7f25', '', 2, 1),
 (7, '41000113', 'Aguirre', 'Brian', 'agubri@correo.com', '2dfa174ae2688ec55d00f57c5a0a7783ba1f0e2981ab7df9f1cf933686c15274', '', 2, 1),
 (8, '51000111', 'Fernandez', 'Benito', 'ferben@correo.com', 'f127f4e9e4248f77eaa446ea9bff721e3e79eedf114ba6e1cfc633853ef07b4c', '', 3, 1),
-(10, '51000112', 'Gomez', 'Silvia', 'gomsil@correo.com', '601de117008d80e65ffad05dce97462d8f1b1e9aad6d68cf2b289703b8366b52', '', 3, 1);
+(10, '51000112', 'Gomez', 'Silvia', 'gomsil@correo.com', '76a8c23df7d396e6ff724af4263a4f1cb3f9858e1c29c449ac1153b34020bd26', '', 3, 1),
+(9, '41000114', 'Perez', 'Carlos', 'carlosperez@correo.com', 'bbe8be0ee37e9f1ce1cd25893151b35b6537ff607beca72e7b19814d2c7196c2', '', 2, 1);
+
 
 -- --------------------------------------------------------
 

--- a/tp-final-integrador/src/controllers/turnos.controller.js
+++ b/tp-final-integrador/src/controllers/turnos.controller.js
@@ -8,7 +8,10 @@ import { successResponse } from '../helpers/response.helper.js';
 
 export const registrarTurno = async (req, res) => {
   const data = matchedData(req);
-  const nuevoTurno = await turnosService.registrarTurno(data);
+  const nuevoTurno = await turnosService.registrarTurno(data, {
+    id: req.user.id,
+    role: req.user.rol,
+  });
 
   return successResponse(res, nuevoTurno, 201);
 };

--- a/tp-final-integrador/src/controllers/turnos.controller.js
+++ b/tp-final-integrador/src/controllers/turnos.controller.js
@@ -12,3 +12,8 @@ export const registrarTurno = async (req, res) => {
 
   return successResponse(res, nuevoTurno, 201);
 };
+
+export const listarTurnosPropios = async (req, res) => {
+  const turnos = await turnosService.listarTurnosPropios(req.user);
+  return successResponse(res, turnos);
+};

--- a/tp-final-integrador/src/controllers/turnos.controller.js
+++ b/tp-final-integrador/src/controllers/turnos.controller.js
@@ -17,3 +17,10 @@ export const listarTurnosPropios = async (req, res) => {
   const turnos = await turnosService.listarTurnosPropios(req.user);
   return successResponse(res, turnos);
 };
+
+export const marcarComoAtendido = async (req, res) => {
+  const { id } = matchedData(req);
+  const turnoActualizado = await turnosService.marcarComoAtendido(id, req.user.id);
+
+  return successResponse(res, turnoActualizado);
+};

--- a/tp-final-integrador/src/database/medicos.js
+++ b/tp-final-integrador/src/database/medicos.js
@@ -21,6 +21,24 @@ export const findById = async (id) => {
 };
 
 /**
+ * Busca un médico por su ID de usuario.
+ * @param {number} idUsuario
+ * @returns {Promise<Object|null>}
+ */
+export const findByUserId = async (idUsuario) => {
+  const query = `
+    SELECT m.id_medico, m.id_usuario, m.id_especialidad, m.matricula, m.valor_consulta, u.activo
+    FROM medicos m
+    JOIN usuarios u ON m.id_usuario = u.id_usuario
+    WHERE m.id_usuario = ?
+  `;
+  const [rows] = await pool.execute(query, [idUsuario]);
+
+  if (rows.length === 0) return null;
+  return medicosMapper.toDTO(rows[0]);
+};
+
+/**
  * Verifica si un médico atiende una obra social específica de forma activa.
  * @param {number} idMedico
  * @param {number} idObraSocial

--- a/tp-final-integrador/src/database/pacientes.js
+++ b/tp-final-integrador/src/database/pacientes.js
@@ -18,3 +18,21 @@ export const findById = async (id) => {
   if (rows.length === 0) return null;
   return pacientesMapper.toDTO(rows[0]);
 };
+
+/**
+ * Busca un paciente por su ID de usuario.
+ * @param {number} idUsuario
+ * @returns {Promise<Object|null>}
+ */
+export const findByUserId = async (idUsuario) => {
+  const query = `
+    SELECT p.id_paciente, p.id_usuario, p.id_obra_social, u.activo
+    FROM pacientes p
+    JOIN usuarios u ON p.id_usuario = u.id_usuario
+    WHERE p.id_usuario = ?
+  `;
+  const [rows] = await pool.execute(query, [idUsuario]);
+
+  if (rows.length === 0) return null;
+  return pacientesMapper.toDTO(rows[0]);
+};

--- a/tp-final-integrador/src/database/turnos.js
+++ b/tp-final-integrador/src/database/turnos.js
@@ -1,5 +1,6 @@
 import { pool } from '../config/db.js';
 import { DB_STATUS } from '../constants/common.constants.js';
+import * as turnosMapper from './turnos.mapper.js';
 
 /**
  * Registra un nuevo turno.
@@ -24,6 +25,55 @@ export const create = async (data) => {
   ]);
 
   return result.insertId;
+};
+
+/**
+ * Obtiene los turnos de un médico.
+ * @param {number} idMedico
+ * @returns {Promise<Object[]>}
+ */
+export const findByMedicoId = async (idMedico) => {
+  const query = `
+    SELECT 
+      tr.*, 
+      u.apellido AS paciente_apellido, 
+      u.nombres AS paciente_nombres, 
+      u.email AS paciente_email, 
+      os.nombre AS obra_social_nombre
+    FROM turnos_reservas tr
+    JOIN pacientes p ON tr.id_paciente = p.id_paciente
+    JOIN usuarios u ON p.id_usuario = u.id_usuario
+    JOIN obras_sociales os ON tr.id_obra_social = os.id_obra_social
+    WHERE tr.id_medico = ? AND tr.activo = ?
+    ORDER BY tr.fecha_hora DESC
+  `;
+  const [rows] = await pool.execute(query, [idMedico, DB_STATUS.ACTIVE]);
+  return turnosMapper.toDTOs(rows, { omitirMedico: true });
+};
+
+/**
+ * Obtiene los turnos de un paciente.
+ * @param {number} idPaciente
+ * @returns {Promise<Object[]>}
+ */
+export const findByPacienteId = async (idPaciente) => {
+  const query = `
+    SELECT 
+      tr.*, 
+      u.apellido AS medico_apellido, 
+      u.nombres AS medico_nombres, 
+      e.nombre AS especialidad, 
+      os.nombre AS obra_social_nombre
+    FROM turnos_reservas tr
+    JOIN medicos m ON tr.id_medico = m.id_medico
+    JOIN usuarios u ON m.id_usuario = u.id_usuario
+    JOIN especialidades e ON m.id_especialidad = e.id_especialidad
+    JOIN obras_sociales os ON tr.id_obra_social = os.id_obra_social
+    WHERE tr.id_paciente = ? AND tr.activo = ?
+    ORDER BY tr.fecha_hora DESC
+  `;
+  const [rows] = await pool.execute(query, [idPaciente, DB_STATUS.ACTIVE]);
+  return turnosMapper.toDTOs(rows, { omitirPaciente: true });
 };
 
 /**

--- a/tp-final-integrador/src/database/turnos.js
+++ b/tp-final-integrador/src/database/turnos.js
@@ -105,3 +105,34 @@ export const existsByMedicoAndFechaHora = async (idMedico, fechaHora) => {
   const [rows] = await pool.execute(query, [idMedico, fechaHora, DB_STATUS.ACTIVE]);
   return rows.length > 0;
 };
+
+/**
+ * Busca un turno por su ID.
+ * @param {number} id
+ * @returns {Promise<Object|null>}
+ */
+export const findById = async (id) => {
+  const query = `
+    SELECT * FROM turnos_reservas
+    WHERE id_turno_reserva = ?
+  `;
+  const [rows] = await pool.execute(query, [id]);
+
+  if (rows.length === 0) return null;
+  return turnosMapper.toDTO(rows[0]);
+};
+
+/**
+ * Actualiza el estado de atención de un turno.
+ * @param {number} id
+ * @param {number} atendido - 1 para atendido, 0 para no atendido.
+ * @returns {Promise<void>}
+ */
+export const updateAtendido = async (id, atendido) => {
+  const query = `
+    UPDATE turnos_reservas
+    SET atendido = ?
+    WHERE id_turno_reserva = ?
+  `;
+  await pool.execute(query, [atendido, id]);
+};

--- a/tp-final-integrador/src/database/turnos.mapper.js
+++ b/tp-final-integrador/src/database/turnos.mapper.js
@@ -1,0 +1,44 @@
+/**
+ * Mapper para la entidad Turno.
+ */
+
+export const toDTO = (row, options = {}) => {
+  if (!row) return null;
+
+  const { omitirMedico = false, omitirPaciente = false } = options;
+
+  return {
+    id: row.id_turno_reserva,
+    fechaHora: row.fecha_hora,
+    valorTotal: row.valor_total ? Number(row.valor_total) : 0,
+    atendido: Boolean(row.atendido),
+    activo: row.activo,
+    medico:
+      !omitirMedico && (row.medico_apellido || row.id_medico)
+        ? {
+            id: row.id_medico,
+            apellido: row.medico_apellido,
+            nombres: row.medico_nombres,
+            especialidad: row.especialidad,
+          }
+        : undefined,
+    paciente:
+      !omitirPaciente && (row.paciente_apellido || row.id_paciente)
+        ? {
+            id: row.id_paciente,
+            apellido: row.paciente_apellido,
+            nombres: row.paciente_nombres,
+            email: row.paciente_email,
+          }
+        : undefined,
+    obraSocial:
+      row.obra_social_nombre || row.id_obra_social
+        ? {
+            id: row.id_obra_social,
+            nombre: row.obra_social_nombre,
+          }
+        : undefined,
+  };
+};
+
+export const toDTOs = (rows, options = {}) => rows.map((row) => toDTO(row, options));

--- a/tp-final-integrador/src/routes/turnos.routes.js
+++ b/tp-final-integrador/src/routes/turnos.routes.js
@@ -10,15 +10,19 @@ const turnosRouter = Router();
 
 /**
  * Rutas para el módulo de Turnos.
- * Solo el Administrador (Role 3) puede registrar turnos.
  */
 
 turnosRouter.use(authenticateJwt);
-turnosRouter.use(requireRole([ROLES.ADMIN]));
 
 turnosRouter
   .route('/')
-  .post(turnosValidator.validateRegistrarTurno, validateRequest, turnosController.registrarTurno)
-  .all(methodNotAllowedHandler(['POST']));
+  .get(requireRole([ROLES.MEDICO, ROLES.PACIENTE]), turnosController.listarTurnosPropios)
+  .post(
+    requireRole([ROLES.ADMIN]),
+    turnosValidator.validateRegistrarTurno,
+    validateRequest,
+    turnosController.registrarTurno,
+  )
+  .all(methodNotAllowedHandler(['GET', 'POST']));
 
 export default turnosRouter;

--- a/tp-final-integrador/src/routes/turnos.routes.js
+++ b/tp-final-integrador/src/routes/turnos.routes.js
@@ -25,4 +25,14 @@ turnosRouter
   )
   .all(methodNotAllowedHandler(['GET', 'POST']));
 
+turnosRouter
+  .route('/:id/atendido')
+  .patch(
+    requireRole([ROLES.MEDICO]),
+    turnosValidator.validateMarcarAtendido,
+    validateRequest,
+    turnosController.marcarComoAtendido,
+  )
+  .all(methodNotAllowedHandler(['PATCH']));
+
 export default turnosRouter;

--- a/tp-final-integrador/src/routes/turnos.routes.js
+++ b/tp-final-integrador/src/routes/turnos.routes.js
@@ -18,7 +18,7 @@ turnosRouter
   .route('/')
   .get(requireRole([ROLES.MEDICO, ROLES.PACIENTE]), turnosController.listarTurnosPropios)
   .post(
-    requireRole([ROLES.ADMIN]),
+    requireRole([ROLES.ADMIN, ROLES.PACIENTE]),
     turnosValidator.validateRegistrarTurno,
     validateRequest,
     turnosController.registrarTurno,

--- a/tp-final-integrador/src/services/turnos.service.js
+++ b/tp-final-integrador/src/services/turnos.service.js
@@ -57,9 +57,22 @@ export const listarTurnosPropios = async (usuario) => {
 /**
  * Registra un nuevo turno con cálculo de valor_total.
  * @param {Object} data - Datos del turno (idMedico, idPaciente, idObraSocial, fecha, hora).
+ * @param {Object} context - Contexto del usuario que realiza la acción ({ id, role }).
  * @returns {Promise<Object>} Datos del turno creado.
  */
-export const registrarTurno = async (data) => {
+export const registrarTurno = async (data, { id, role }) => {
+  if (role === ROLES.PACIENTE) {
+    const pacientePerfil = await pacientesModel.findByUserId(id);
+
+    if (!pacientePerfil) {
+      throw new AppError(ERROR_CODES.NOT_FOUND, 'Perfil de paciente no encontrado');
+    }
+
+    // Sobrescribimos los IDs con los del perfil del paciente
+    data.idPaciente = pacientePerfil.idPaciente;
+    data.idObraSocial = pacientePerfil.idObraSocial;
+  }
+
   const { idMedico, idPaciente, idObraSocial, fecha, hora } = data;
 
   const medico = await findActiveOrThrow(medicosModel.findById, idMedico, {
@@ -107,19 +120,19 @@ export const registrarTurno = async (data) => {
 
   const fechaHora = `${fecha} ${hora}`;
 
-  const medicoTieneTurno = await turnosModel.existsByMedicoAndFechaHora(idMedico, fechaHora);
-  if (medicoTieneTurno) {
-    throw new AppError(
-      ERROR_CODES.VALIDATION_ERROR,
-      'El médico ya tiene un turno reservado para la misma fecha y hora',
-    );
-  }
-
   const pacienteTieneTurno = await turnosModel.checkPatientOverlap(idPaciente, fechaHora);
   if (pacienteTieneTurno) {
     throw new AppError(
-      ERROR_CODES.VALIDATION_ERROR,
+      ERROR_CODES.DUPLICATE_ENTRY,
       'El paciente ya tiene un turno reservado para la misma fecha y hora',
+    );
+  }
+
+  const medicoTieneTurno = await turnosModel.existsByMedicoAndFechaHora(idMedico, fechaHora);
+  if (medicoTieneTurno) {
+    throw new AppError(
+      ERROR_CODES.DUPLICATE_ENTRY,
+      'El médico ya tiene un turno reservado para la misma fecha y hora',
     );
   }
 

--- a/tp-final-integrador/src/services/turnos.service.js
+++ b/tp-final-integrador/src/services/turnos.service.js
@@ -142,3 +142,40 @@ export const registrarTurno = async (data) => {
     activo: DB_STATUS.ACTIVE,
   };
 };
+
+/**
+ * Marca un turno como atendido.
+ * @param {number} idTurno
+ * @param {number} idUsuario - ID del usuario médico que realiza la acción.
+ * @returns {Promise<Object>} Datos del turno actualizado.
+ */
+export const marcarComoAtendido = async (idTurno, idUsuario) => {
+  const medico = await findActiveOrThrow(medicosModel.findByUserId, idUsuario, {
+    notFoundMessage: 'Perfil de médico no encontrado',
+    inactiveMessage: 'El médico solicitado no se encuentra activo',
+  });
+
+  const turno = await turnosModel.findById(idTurno);
+
+  if (!turno) {
+    throw new AppError(ERROR_CODES.NOT_FOUND, 'El turno solicitado no existe');
+  }
+
+  if (turno.medico.id !== medico.idMedico) {
+    throw new AppError(
+      ERROR_CODES.FORBIDDEN,
+      'No tiene permisos para marcar este turno como atendido',
+    );
+  }
+
+  if (turno.atendido) {
+    throw new AppError(ERROR_CODES.DUPLICATE_ENTRY, 'El turno ya ha sido marcado como atendido');
+  }
+
+  await turnosModel.updateAtendido(idTurno, 1);
+
+  return {
+    ...turno,
+    atendido: 1,
+  };
+};

--- a/tp-final-integrador/src/services/turnos.service.js
+++ b/tp-final-integrador/src/services/turnos.service.js
@@ -4,6 +4,35 @@ import * as pacientesModel from '../database/pacientes.js';
 import * as obrasSocialesModel from '../database/obras_sociales.js';
 import { AppError, ERROR_CODES } from '../helpers/errors.helper.js';
 import { DB_STATUS } from '../constants/common.constants.js';
+import { ROLES } from '../constants/roles.constants.js';
+
+/**
+ * Obtiene los turnos propios del usuario según su rol.
+ * @param {Object} usuario - El usuario autenticado (extraído de req.user).
+ * @returns {Promise<Object[]>} Lista de turnos.
+ */
+export const listarTurnosPropios = async (usuario) => {
+  if (usuario.rol === ROLES.MEDICO) {
+    const medico = await medicosModel.findByUserId(usuario.id);
+    if (!medico) {
+      throw new AppError(ERROR_CODES.NOT_FOUND, 'Perfil de médico no encontrado');
+    }
+    return await turnosModel.findByMedicoId(medico.idMedico);
+  }
+
+  if (usuario.rol === ROLES.PACIENTE) {
+    const paciente = await pacientesModel.findByUserId(usuario.id);
+    if (!paciente) {
+      throw new AppError(ERROR_CODES.NOT_FOUND, 'Perfil de paciente no encontrado');
+    }
+    return await turnosModel.findByPacienteId(paciente.idPaciente);
+  }
+
+  throw new AppError(
+    ERROR_CODES.FORBIDDEN,
+    'El rol del usuario no tiene permisos para esta acción',
+  );
+};
 
 /**
  * Registra un nuevo turno con cálculo de valor_total.

--- a/tp-final-integrador/src/services/turnos.service.js
+++ b/tp-final-integrador/src/services/turnos.service.js
@@ -7,24 +7,44 @@ import { DB_STATUS } from '../constants/common.constants.js';
 import { ROLES } from '../constants/roles.constants.js';
 
 /**
+ * Busca una entidad por ID y lanza un error si no existe o no está activa.
+ * @param {Function} findFn - Función async que recibe el ID y retorna la entidad o null.
+ * @param {*} id - El ID a buscar.
+ * @param {Object} messages - Mensajes de error personalizados.
+ * @param {string} messages.notFoundMessage - Mensaje cuando la entidad no existe.
+ * @param {string} messages.inactiveMessage - Mensaje cuando la entidad está inactiva.
+ * @returns {Promise<Object>} La entidad encontrada y activa.
+ */
+const findActiveOrThrow = async (findFn, id, { notFoundMessage, inactiveMessage }) => {
+  const entity = await findFn(id);
+  if (!entity) {
+    throw new AppError(ERROR_CODES.NOT_FOUND, notFoundMessage);
+  }
+  if (!entity.activo) {
+    throw new AppError(ERROR_CODES.VALIDATION_ERROR, inactiveMessage);
+  }
+  return entity;
+};
+
+/**
  * Obtiene los turnos propios del usuario según su rol.
  * @param {Object} usuario - El usuario autenticado (extraído de req.user).
  * @returns {Promise<Object[]>} Lista de turnos.
  */
 export const listarTurnosPropios = async (usuario) => {
   if (usuario.rol === ROLES.MEDICO) {
-    const medico = await medicosModel.findByUserId(usuario.id);
-    if (!medico) {
-      throw new AppError(ERROR_CODES.NOT_FOUND, 'Perfil de médico no encontrado');
-    }
+    const medico = await findActiveOrThrow(medicosModel.findByUserId, usuario.id, {
+      notFoundMessage: 'Perfil de médico no encontrado',
+      inactiveMessage: 'El médico solicitado no se encuentra activo',
+    });
     return await turnosModel.findByMedicoId(medico.idMedico);
   }
 
   if (usuario.rol === ROLES.PACIENTE) {
-    const paciente = await pacientesModel.findByUserId(usuario.id);
-    if (!paciente) {
-      throw new AppError(ERROR_CODES.NOT_FOUND, 'Perfil de paciente no encontrado');
-    }
+    const paciente = await findActiveOrThrow(pacientesModel.findByUserId, usuario.id, {
+      notFoundMessage: 'Perfil de paciente no encontrado',
+      inactiveMessage: 'El paciente solicitado no se encuentra activo',
+    });
     return await turnosModel.findByPacienteId(paciente.idPaciente);
   }
 
@@ -42,24 +62,15 @@ export const listarTurnosPropios = async (usuario) => {
 export const registrarTurno = async (data) => {
   const { idMedico, idPaciente, idObraSocial, fecha, hora } = data;
 
-  const medico = await medicosModel.findById(idMedico);
-  if (!medico) {
-    throw new AppError(ERROR_CODES.NOT_FOUND, 'El médico solicitado no existe');
-  }
-  if (!medico.activo) {
-    throw new AppError(ERROR_CODES.VALIDATION_ERROR, 'El médico solicitado no se encuentra activo');
-  }
+  const medico = await findActiveOrThrow(medicosModel.findById, idMedico, {
+    notFoundMessage: 'El médico solicitado no existe',
+    inactiveMessage: 'El médico solicitado no se encuentra activo',
+  });
 
-  const paciente = await pacientesModel.findById(idPaciente);
-  if (!paciente) {
-    throw new AppError(ERROR_CODES.NOT_FOUND, 'El paciente solicitado no existe');
-  }
-  if (!paciente.activo) {
-    throw new AppError(
-      ERROR_CODES.VALIDATION_ERROR,
-      'El paciente solicitado no se encuentra activo',
-    );
-  }
+  const paciente = await findActiveOrThrow(pacientesModel.findById, idPaciente, {
+    notFoundMessage: 'El paciente solicitado no existe',
+    inactiveMessage: 'El paciente solicitado no se encuentra activo',
+  });
 
   if (paciente.idObraSocial !== idObraSocial) {
     throw new AppError(
@@ -68,16 +79,14 @@ export const registrarTurno = async (data) => {
     );
   }
 
-  const obraSocial = await obrasSocialesModel.findById(idObraSocial, false);
-  if (!obraSocial) {
-    throw new AppError(ERROR_CODES.NOT_FOUND, 'La obra social solicitada no existe');
-  }
-  if (!obraSocial.activo) {
-    throw new AppError(
-      ERROR_CODES.VALIDATION_ERROR,
-      'La obra social solicitada no se encuentra activa',
-    );
-  }
+  const obraSocial = await findActiveOrThrow(
+    (id) => obrasSocialesModel.findById(id, false),
+    idObraSocial,
+    {
+      notFoundMessage: 'La obra social solicitada no existe',
+      inactiveMessage: 'La obra social solicitada no se encuentra activa',
+    },
+  );
 
   if (!obraSocial.esParticular) {
     const aceptaObraSocial = await medicosModel.acceptsObraSocial(idMedico, idObraSocial);

--- a/tp-final-integrador/src/validators/turnos.validator.js
+++ b/tp-final-integrador/src/validators/turnos.validator.js
@@ -1,4 +1,4 @@
-import { body } from 'express-validator';
+import { body, param } from 'express-validator';
 
 /**
  * Validaciones para el módulo de Turnos
@@ -46,4 +46,13 @@ export const validateRegistrarTurno = [
     .withMessage('La hora es requerida')
     .matches(/^([01]\d|2[0-3]):([0-5]\d)$/)
     .withMessage('La hora debe tener un formato válido (HH:mm)'),
+];
+
+export const validateMarcarAtendido = [
+  param('id')
+    .notEmpty()
+    .withMessage('El ID del turno es requerido')
+    .isInt({ min: 1 })
+    .withMessage('El ID del turno debe ser un número entero positivo')
+    .toInt(),
 ];

--- a/tp-final-integrador/src/validators/turnos.validator.js
+++ b/tp-final-integrador/src/validators/turnos.validator.js
@@ -1,4 +1,5 @@
 import { body, param } from 'express-validator';
+import { ROLES } from '../constants/roles.constants.js';
 
 /**
  * Validaciones para el módulo de Turnos
@@ -13,6 +14,7 @@ export const validateRegistrarTurno = [
     .toInt(),
 
   body('idPaciente')
+    .if((value, { req }) => req.user?.rol === ROLES.ADMIN)
     .notEmpty()
     .withMessage('El ID del paciente es requerido')
     .isInt({ min: 1 })
@@ -20,6 +22,7 @@ export const validateRegistrarTurno = [
     .toInt(),
 
   body('idObraSocial')
+    .if((value, { req }) => req.user?.rol === ROLES.ADMIN)
     .notEmpty()
     .withMessage('El ID de la obra social es requerido')
     .isInt({ min: 1 })

--- a/tp-final-integrador/tests/modules/turnos.list.test.js
+++ b/tp-final-integrador/tests/modules/turnos.list.test.js
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll } from 'vitest';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { app } from '../../src/app.js';
+import { pool } from '../../src/config/db.js';
+import { setupTestDB } from '../setup/db.js';
+import { ROLES } from '../../src/constants/roles.constants.js';
+
+describe('Turnos List - Integration Tests', () => {
+  let adminToken;
+  let patientToken;
+  let doctorToken;
+  const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+
+  beforeEach(async () => {
+    await setupTestDB();
+
+    // 1. Especialidad
+    await pool.execute(
+      'INSERT INTO especialidades (id_especialidad, nombre, activo) VALUES (?, ?, ?)',
+      [1, 'PEDIATRÍA', 1],
+    );
+
+    // 2. Obra Social
+    await pool.execute(
+      'INSERT INTO obras_sociales (id_obra_social, nombre, descripcion, porcentaje_descuento, es_particular, activo) VALUES (?, ?, ?, ?, ?, ?)',
+      [1, 'OSDE', 'Plan 210', 0.1, 0, 1],
+    );
+
+    // 3. Usuarios
+    await pool.execute(
+      'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      [1, '11111111', 'Admin', 'Root', 'admin@test.com', 'hash', '', ROLES.ADMIN, 1],
+    );
+    await pool.execute(
+      'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      [2, '22222222', 'Medico', 'Doc', 'medico@test.com', 'hash', '', ROLES.MEDICO, 1],
+    );
+    await pool.execute(
+      'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      [3, '33333333', 'Paciente', 'User', 'paciente@test.com', 'hash', '', ROLES.PACIENTE, 1],
+    );
+
+    // 4. Medico
+    await pool.execute(
+      'INSERT INTO medicos (id_medico, id_usuario, id_especialidad, matricula, valor_consulta) VALUES (?, ?, ?, ?, ?)',
+      [1, 2, 1, 2000, 5000.0],
+    );
+
+    // 5. Paciente
+    await pool.execute(
+      'INSERT INTO pacientes (id_paciente, id_usuario, id_obra_social) VALUES (?, ?, ?)',
+      [1, 3, 1],
+    );
+
+    // 6. Turno
+    await pool.execute(
+      'INSERT INTO turnos_reservas (id_medico, id_paciente, id_obra_social, fecha_hora, valor_total, atendido, activo) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      [1, 1, 1, '2026-07-15 14:30:00', 4500.0, 0, 1],
+    );
+
+    // Tokens
+    adminToken = jwt.sign({ id: 1, rol: ROLES.ADMIN, documento: '11111111' }, JWT_SECRET);
+    doctorToken = jwt.sign({ id: 2, rol: ROLES.MEDICO, documento: '22222222' }, JWT_SECRET);
+    patientToken = jwt.sign({ id: 3, rol: ROLES.PACIENTE, documento: '33333333' }, JWT_SECRET);
+  });
+
+  afterEach(async () => {
+    await setupTestDB(); // setupTestDB ya limpia la base
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  describe('GET /api/v1/turnos', () => {
+    it('Doctor should see their own turnos', async () => {
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${doctorToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(Array.isArray(response.body.data)).toBe(true);
+      expect(response.body.data.length).toBe(1);
+      expect(response.body.data[0].paciente).toBeDefined();
+      expect(response.body.data[0].paciente.id).toBe(1);
+      expect(response.body.data[0].paciente.apellido).toBe('Paciente');
+      expect(response.body.data[0].medico).toBeUndefined();
+    });
+
+    it('Patient should see their own turnos', async () => {
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${patientToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(Array.isArray(response.body.data)).toBe(true);
+      expect(response.body.data.length).toBe(1);
+      expect(response.body.data[0].medico).toBeDefined();
+      expect(response.body.data[0].medico.id).toBe(1);
+      expect(response.body.data[0].medico.apellido).toBe('Medico');
+      expect(response.body.data[0].paciente).toBeUndefined();
+    });
+
+    it('Admin should be forbidden from listing turnos (not a doctor or patient)', async () => {
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(response.status).toBe(403);
+    });
+
+    it('Doctor without profile should return 404', async () => {
+      // Create user with doctor role but no medicos entry
+      await pool.execute(
+        'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        [4, '44444444', 'Ghost', 'Doc', 'ghost@test.com', 'hash', '', ROLES.MEDICO, 1],
+      );
+      const ghostToken = jwt.sign({ id: 4, rol: ROLES.MEDICO, documento: '44444444' }, JWT_SECRET);
+
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${ghostToken}`);
+
+      expect(response.status).toBe(404);
+      expect(response.body.error.message).toBe('Perfil de médico no encontrado');
+    });
+
+    it('Patient without profile should return 404', async () => {
+      // Create user with patient role but no pacientes entry
+      await pool.execute(
+        'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        [5, '55555555', 'Ghost', 'Patient', 'ghostpatient@test.com', 'hash', '', ROLES.PACIENTE, 1],
+      );
+      const ghostToken = jwt.sign(
+        { id: 5, rol: ROLES.PACIENTE, documento: '55555555' },
+        JWT_SECRET,
+      );
+
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${ghostToken}`);
+
+      expect(response.status).toBe(404);
+      expect(response.body.error.message).toBe('Perfil de paciente no encontrado');
+    });
+
+    it('Should not list inactive turnos', async () => {
+      // Create an inactive turno
+      await pool.execute(
+        'INSERT INTO turnos_reservas (id_medico, id_paciente, id_obra_social, fecha_hora, valor_total, atendido, activo) VALUES (?, ?, ?, ?, ?, ?, ?)',
+        [1, 1, 1, '2026-07-16 10:00:00', 4500.0, 0, 0], // Activo = 0
+      );
+
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${patientToken}`);
+
+      expect(response.status).toBe(200);
+      // Should only see the active one from beforeEach
+      expect(response.body.data.length).toBe(1);
+      expect(response.body.data[0].fechaHora).not.toContain('2026-07-16 10:00:00');
+    });
+
+    it('Should return turnos ordered by date descending', async () => {
+      // Add a second turno for the same patient, but EARLIER than the one in beforeEach (2026-07-15 14:30:00)
+      await pool.execute(
+        'INSERT INTO turnos_reservas (id_medico, id_paciente, id_obra_social, fecha_hora, valor_total, atendido, activo) VALUES (?, ?, ?, ?, ?, ?, ?)',
+        [1, 1, 1, '2026-07-10 09:00:00', 4500.0, 0, 1],
+      );
+
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${patientToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.length).toBe(2);
+
+      // The first one should be the LATEST (July 15th)
+      const firstDate = new Date(response.body.data[0].fechaHora);
+      const secondDate = new Date(response.body.data[1].fechaHora);
+
+      expect(firstDate.getTime()).toBeGreaterThan(secondDate.getTime());
+      expect(response.body.data[0].fechaHora).toContain('2026-07-15');
+      expect(response.body.data[1].fechaHora).toContain('2026-07-10');
+    });
+
+    it('Should return an empty array if no turnos found', async () => {
+      // Create a new patient without turnos
+      await pool.execute(
+        'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        [6, '66666666', 'New', 'Patient', 'new@test.com', 'hash', '', ROLES.PACIENTE, 1],
+      );
+      await pool.execute(
+        'INSERT INTO pacientes (id_paciente, id_usuario, id_obra_social) VALUES (?, ?, ?)',
+        [2, 6, 1],
+      );
+      const newToken = jwt.sign({ id: 6, rol: ROLES.PACIENTE, documento: '66666666' }, JWT_SECRET);
+
+      const response = await request(app)
+        .get('/api/v1/turnos')
+        .set('Authorization', `Bearer ${newToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data).toEqual([]);
+    });
+
+    it('Should return 401 if no token is provided', async () => {
+      const response = await request(app).get('/api/v1/turnos');
+      expect(response.status).toBe(401);
+    });
+  });
+});

--- a/tp-final-integrador/tests/modules/turnos.service.test.js
+++ b/tp-final-integrador/tests/modules/turnos.service.test.js
@@ -117,7 +117,7 @@ describe('Turnos Service - Unit Tests', () => {
       obrasSocialesModel.findById.mockResolvedValue(mockObraSocial);
       turnosModel.create.mockResolvedValue(100);
 
-      const result = await turnosService.registrarTurno(data);
+      const result = await turnosService.registrarTurno(data, { id: 1, role: ROLES.ADMIN });
 
       expect(turnosModel.create).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -150,7 +150,7 @@ describe('Turnos Service - Unit Tests', () => {
       obrasSocialesModel.findById.mockResolvedValue(mockObraSocial);
       turnosModel.create.mockResolvedValue(101);
 
-      const result = await turnosService.registrarTurno(data);
+      const result = await turnosService.registrarTurno(data, { id: 1, role: ROLES.ADMIN });
 
       expect(turnosModel.create).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -166,19 +166,66 @@ describe('Turnos Service - Unit Tests', () => {
     });
   });
 
+  describe('registrarTurno() - Identity Resolution (PACIENTE)', () => {
+    it('debería usar idPaciente e idObraSocial del perfil si el rol es PACIENTE, ignorando el payload', async () => {
+      const data = {
+        idMedico: 1,
+        idPaciente: 999, // Ignorado
+        idObraSocial: 999, // Ignorado
+        fecha: '2026-07-15',
+        hora: '14:30',
+      };
+
+      const mockPacientePerfil = { idPaciente: 5, idObraSocial: 2, activo: true };
+      const mockMedico = { idMedico: 1, valorConsulta: 5000, activo: true };
+      const mockObraSocial = { id: 2, porcentajeDescuento: 0, esParticular: true, activo: true };
+
+      pacientesModel.findByUserId.mockResolvedValue(mockPacientePerfil);
+      medicosModel.findById.mockResolvedValue(mockMedico);
+      pacientesModel.findById.mockResolvedValue(mockPacientePerfil); // Llamado interno para validación de existencia
+      obrasSocialesModel.findById.mockResolvedValue(mockObraSocial);
+      turnosModel.create.mockResolvedValue(200);
+
+      const result = await turnosService.registrarTurno(data, { id: 3, role: ROLES.PACIENTE });
+
+      expect(pacientesModel.findByUserId).toHaveBeenCalledWith(3);
+      expect(turnosModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          idPaciente: 5,
+          idObraSocial: 2,
+        }),
+      );
+      expect(result.idPaciente).toBe(5);
+      expect(result.idObraSocial).toBe(2);
+    });
+
+    it('debería lanzar NOT_FOUND si el paciente no tiene perfil al intentar registrar un turno', async () => {
+      pacientesModel.findByUserId.mockResolvedValue(null);
+
+      await expect(
+        turnosService.registrarTurno({}, { id: 3, role: ROLES.PACIENTE }),
+      ).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+        message: 'Perfil de paciente no encontrado',
+      });
+    });
+  });
+
   describe('registrarTurno() - Validations', () => {
     it('debería lanzar error si el médico no existe', async () => {
       medicosModel.findById.mockResolvedValue(null);
 
-      await expect(turnosService.registrarTurno({ idMedico: 999 })).rejects.toThrow(
-        'El médico solicitado no existe',
-      );
+      await expect(
+        turnosService.registrarTurno({ idMedico: 999 }, { id: 1, role: ROLES.ADMIN }),
+      ).rejects.toThrow('El médico solicitado no existe');
     });
 
     it('debería lanzar error si el médico no está activo', async () => {
       medicosModel.findById.mockResolvedValue({ idMedico: 1, activo: false });
 
-      await expect(turnosService.registrarTurno({ idMedico: 1 })).rejects.toMatchObject({
+      await expect(
+        turnosService.registrarTurno({ idMedico: 1 }, { id: 1, role: ROLES.ADMIN }),
+      ).rejects.toMatchObject({
         status: 422,
         code: 'VALIDATION_ERROR',
         message: 'El médico solicitado no se encuentra activo',
@@ -189,9 +236,12 @@ describe('Turnos Service - Unit Tests', () => {
       medicosModel.findById.mockResolvedValue({ idMedico: 1, activo: true });
       pacientesModel.findById.mockResolvedValue(null);
 
-      await expect(turnosService.registrarTurno({ idMedico: 1, idPaciente: 999 })).rejects.toThrow(
-        'El paciente solicitado no existe',
-      );
+      await expect(
+        turnosService.registrarTurno(
+          { idMedico: 1, idPaciente: 999 },
+          { id: 1, role: ROLES.ADMIN },
+        ),
+      ).rejects.toThrow('El paciente solicitado no existe');
     });
 
     it('debería lanzar error si el paciente no está activo', async () => {
@@ -199,7 +249,10 @@ describe('Turnos Service - Unit Tests', () => {
       pacientesModel.findById.mockResolvedValue({ idPaciente: 1, idObraSocial: 1, activo: false });
 
       await expect(
-        turnosService.registrarTurno({ idMedico: 1, idPaciente: 1, idObraSocial: 1 }),
+        turnosService.registrarTurno(
+          { idMedico: 1, idPaciente: 1, idObraSocial: 1 },
+          { id: 1, role: ROLES.ADMIN },
+        ),
       ).rejects.toMatchObject({
         status: 422,
         code: 'VALIDATION_ERROR',
@@ -212,7 +265,10 @@ describe('Turnos Service - Unit Tests', () => {
       pacientesModel.findById.mockResolvedValue({ idPaciente: 1, idObraSocial: 1, activo: true });
 
       await expect(
-        turnosService.registrarTurno({ idMedico: 1, idPaciente: 1, idObraSocial: 2 }),
+        turnosService.registrarTurno(
+          { idMedico: 1, idPaciente: 1, idObraSocial: 2 },
+          { id: 1, role: ROLES.ADMIN },
+        ),
       ).rejects.toMatchObject({
         status: 422,
         code: 'VALIDATION_ERROR',
@@ -226,7 +282,10 @@ describe('Turnos Service - Unit Tests', () => {
       obrasSocialesModel.findById.mockResolvedValue(null);
 
       await expect(
-        turnosService.registrarTurno({ idMedico: 1, idPaciente: 1, idObraSocial: 999 }),
+        turnosService.registrarTurno(
+          { idMedico: 1, idPaciente: 1, idObraSocial: 999 },
+          { id: 1, role: ROLES.ADMIN },
+        ),
       ).rejects.toThrow('La obra social solicitada no existe');
     });
 
@@ -236,7 +295,10 @@ describe('Turnos Service - Unit Tests', () => {
       obrasSocialesModel.findById.mockResolvedValue({ id: 1, activo: false });
 
       await expect(
-        turnosService.registrarTurno({ idMedico: 1, idPaciente: 1, idObraSocial: 1 }),
+        turnosService.registrarTurno(
+          { idMedico: 1, idPaciente: 1, idObraSocial: 1 },
+          { id: 1, role: ROLES.ADMIN },
+        ),
       ).rejects.toMatchObject({
         status: 422,
         code: 'VALIDATION_ERROR',
@@ -251,7 +313,10 @@ describe('Turnos Service - Unit Tests', () => {
       medicosModel.acceptsObraSocial.mockResolvedValue(false);
 
       await expect(
-        turnosService.registrarTurno({ idMedico: 1, idPaciente: 1, idObraSocial: 1 }),
+        turnosService.registrarTurno(
+          { idMedico: 1, idPaciente: 1, idObraSocial: 1 },
+          { id: 1, role: ROLES.ADMIN },
+        ),
       ).rejects.toMatchObject({
         status: 422,
         code: 'VALIDATION_ERROR',
@@ -278,7 +343,7 @@ describe('Turnos Service - Unit Tests', () => {
       medicosModel.acceptsObraSocial.mockResolvedValue(true);
       turnosModel.create.mockResolvedValue(100);
 
-      const result = await turnosService.registrarTurno(data);
+      const result = await turnosService.registrarTurno(data, { id: 1, role: ROLES.ADMIN });
 
       expect(medicosModel.acceptsObraSocial).toHaveBeenCalledWith(1, 1);
       expect(result.idTurno).toBe(100);
@@ -302,7 +367,7 @@ describe('Turnos Service - Unit Tests', () => {
       });
       turnosModel.create.mockResolvedValue(100);
 
-      const result = await turnosService.registrarTurno(data);
+      const result = await turnosService.registrarTurno(data, { id: 1, role: ROLES.ADMIN });
 
       expect(medicosModel.acceptsObraSocial).not.toHaveBeenCalled();
       expect(result.idTurno).toBe(100);
@@ -321,9 +386,11 @@ describe('Turnos Service - Unit Tests', () => {
       obrasSocialesModel.findById.mockResolvedValue({ id: 1, activo: true, esParticular: false });
       turnosModel.existsByMedicoAndFechaHora.mockResolvedValue(true);
 
-      await expect(turnosService.registrarTurno(data)).rejects.toMatchObject({
-        status: 422,
-        code: 'VALIDATION_ERROR',
+      await expect(
+        turnosService.registrarTurno(data, { id: 1, role: ROLES.ADMIN }),
+      ).rejects.toMatchObject({
+        status: 409,
+        code: 'DUPLICATE_ENTRY',
         message: 'El médico ya tiene un turno reservado para la misma fecha y hora',
       });
     });
@@ -341,9 +408,13 @@ describe('Turnos Service - Unit Tests', () => {
       obrasSocialesModel.findById.mockResolvedValue({ id: 1, activo: true, esParticular: false });
       turnosModel.checkPatientOverlap.mockResolvedValue(true);
 
-      await expect(turnosService.registrarTurno(data)).rejects.toThrow(
-        'El paciente ya tiene un turno reservado para la misma fecha y hora',
-      );
+      await expect(
+        turnosService.registrarTurno(data, { id: 1, role: ROLES.ADMIN }),
+      ).rejects.toMatchObject({
+        status: 409,
+        code: 'DUPLICATE_ENTRY',
+        message: 'El paciente ya tiene un turno reservado para la misma fecha y hora',
+      });
     });
   });
 

--- a/tp-final-integrador/tests/modules/turnos.service.test.js
+++ b/tp-final-integrador/tests/modules/turnos.service.test.js
@@ -4,20 +4,25 @@ import * as turnosModel from '../../src/database/turnos.js';
 import * as medicosModel from '../../src/database/medicos.js';
 import * as pacientesModel from '../../src/database/pacientes.js';
 import * as obrasSocialesModel from '../../src/database/obras_sociales.js';
+import { ROLES } from '../../src/constants/roles.constants.js';
 
 vi.mock('../../src/database/turnos.js', () => ({
   create: vi.fn(),
   checkPatientOverlap: vi.fn(),
   existsByMedicoAndFechaHora: vi.fn(),
+  findByMedicoId: vi.fn(),
+  findByPacienteId: vi.fn(),
 }));
 
 vi.mock('../../src/database/medicos.js', () => ({
   findById: vi.fn(),
+  findByUserId: vi.fn(),
   acceptsObraSocial: vi.fn(),
 }));
 
 vi.mock('../../src/database/pacientes.js', () => ({
   findById: vi.fn(),
+  findByUserId: vi.fn(),
 }));
 
 vi.mock('../../src/database/obras_sociales.js', () => ({
@@ -30,6 +35,65 @@ describe('Turnos Service - Unit Tests', () => {
     medicosModel.acceptsObraSocial.mockResolvedValue(true);
     turnosModel.checkPatientOverlap.mockResolvedValue(false);
     turnosModel.existsByMedicoAndFechaHora.mockResolvedValue(false);
+  });
+
+  describe('listarTurnosPropios()', () => {
+    it('debería retornar los turnos del médico cuando el rol es MEDICO', async () => {
+      const mockMedico = { idMedico: 1 };
+      const mockTurnos = [{ id: 1, fecha: '2026-07-15' }];
+      medicosModel.findByUserId.mockResolvedValue(mockMedico);
+      turnosModel.findByMedicoId.mockResolvedValue(mockTurnos);
+
+      const result = await turnosService.listarTurnosPropios({ id: 2, rol: ROLES.MEDICO });
+
+      expect(medicosModel.findByUserId).toHaveBeenCalledWith(2);
+      expect(turnosModel.findByMedicoId).toHaveBeenCalledWith(1);
+      expect(result).toEqual(mockTurnos);
+    });
+
+    it('debería lanzar NOT_FOUND si el médico no tiene perfil', async () => {
+      medicosModel.findByUserId.mockResolvedValue(null);
+
+      await expect(
+        turnosService.listarTurnosPropios({ id: 99, rol: ROLES.MEDICO }),
+      ).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+        message: 'Perfil de médico no encontrado',
+      });
+    });
+
+    it('debería retornar los turnos del paciente cuando el rol es PACIENTE', async () => {
+      const mockPaciente = { idPaciente: 5 };
+      const mockTurnos = [{ id: 2, fecha: '2026-08-10' }];
+      pacientesModel.findByUserId.mockResolvedValue(mockPaciente);
+      turnosModel.findByPacienteId.mockResolvedValue(mockTurnos);
+
+      const result = await turnosService.listarTurnosPropios({ id: 3, rol: ROLES.PACIENTE });
+
+      expect(pacientesModel.findByUserId).toHaveBeenCalledWith(3);
+      expect(turnosModel.findByPacienteId).toHaveBeenCalledWith(5);
+      expect(result).toEqual(mockTurnos);
+    });
+
+    it('debería lanzar NOT_FOUND si el paciente no tiene perfil', async () => {
+      pacientesModel.findByUserId.mockResolvedValue(null);
+
+      await expect(
+        turnosService.listarTurnosPropios({ id: 99, rol: ROLES.PACIENTE }),
+      ).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+        message: 'Perfil de paciente no encontrado',
+      });
+    });
+
+    it('debería lanzar FORBIDDEN si el rol no es médico ni paciente', async () => {
+      await expect(
+        turnosService.listarTurnosPropios({ id: 1, rol: 'admin' }),
+      ).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+        message: 'El rol del usuario no tiene permisos para esta acción',
+      });
+    });
   });
 
   describe('registrarTurno() - Calculation Logic', () => {

--- a/tp-final-integrador/tests/modules/turnos.service.test.js
+++ b/tp-final-integrador/tests/modules/turnos.service.test.js
@@ -12,6 +12,8 @@ vi.mock('../../src/database/turnos.js', () => ({
   existsByMedicoAndFechaHora: vi.fn(),
   findByMedicoId: vi.fn(),
   findByPacienteId: vi.fn(),
+  findById: vi.fn(),
+  updateAtendido: vi.fn(),
 }));
 
 vi.mock('../../src/database/medicos.js', () => ({
@@ -39,7 +41,7 @@ describe('Turnos Service - Unit Tests', () => {
 
   describe('listarTurnosPropios()', () => {
     it('debería retornar los turnos del médico cuando el rol es MEDICO', async () => {
-      const mockMedico = { idMedico: 1 };
+      const mockMedico = { idMedico: 1, activo: true };
       const mockTurnos = [{ id: 1, fecha: '2026-07-15' }];
       medicosModel.findByUserId.mockResolvedValue(mockMedico);
       turnosModel.findByMedicoId.mockResolvedValue(mockTurnos);
@@ -63,7 +65,7 @@ describe('Turnos Service - Unit Tests', () => {
     });
 
     it('debería retornar los turnos del paciente cuando el rol es PACIENTE', async () => {
-      const mockPaciente = { idPaciente: 5 };
+      const mockPaciente = { idPaciente: 5, activo: true };
       const mockTurnos = [{ id: 2, fecha: '2026-08-10' }];
       pacientesModel.findByUserId.mockResolvedValue(mockPaciente);
       turnosModel.findByPacienteId.mockResolvedValue(mockTurnos);
@@ -342,6 +344,61 @@ describe('Turnos Service - Unit Tests', () => {
       await expect(turnosService.registrarTurno(data)).rejects.toThrow(
         'El paciente ya tiene un turno reservado para la misma fecha y hora',
       );
+    });
+  });
+
+  describe('marcarComoAtendido()', () => {
+    it('debería marcar un turno como atendido exitosamente', async () => {
+      const mockMedico = { idMedico: 10, activo: true };
+      const mockTurno = { id: 5, medico: { id: 10 }, atendido: false };
+
+      medicosModel.findByUserId.mockResolvedValue(mockMedico);
+      turnosModel.findById.mockResolvedValue(mockTurno);
+      turnosModel.updateAtendido.mockResolvedValue();
+
+      const result = await turnosService.marcarComoAtendido(5, 1);
+
+      expect(medicosModel.findByUserId).toHaveBeenCalledWith(1);
+      expect(turnosModel.findById).toHaveBeenCalledWith(5);
+      expect(turnosModel.updateAtendido).toHaveBeenCalledWith(5, 1);
+      expect(result.atendido).toBe(1);
+    });
+
+    it('debería lanzar FORBIDDEN si el turno no pertenece al médico', async () => {
+      const mockMedico = { idMedico: 10, activo: true };
+      const mockTurno = { id: 5, medico: { id: 11 }, atendido: false };
+
+      medicosModel.findByUserId.mockResolvedValue(mockMedico);
+      turnosModel.findById.mockResolvedValue(mockTurno);
+
+      await expect(turnosService.marcarComoAtendido(5, 1)).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+        message: 'No tiene permisos para marcar este turno como atendido',
+      });
+    });
+
+    it('debería lanzar DUPLICATE_ENTRY si el turno ya fue atendido', async () => {
+      const mockMedico = { idMedico: 10, activo: true };
+      const mockTurno = { id: 5, medico: { id: 10 }, atendido: true };
+
+      medicosModel.findByUserId.mockResolvedValue(mockMedico);
+      turnosModel.findById.mockResolvedValue(mockTurno);
+
+      await expect(turnosService.marcarComoAtendido(5, 1)).rejects.toMatchObject({
+        code: 'DUPLICATE_ENTRY',
+        message: 'El turno ya ha sido marcado como atendido',
+      });
+    });
+
+    it('debería lanzar NOT_FOUND si el turno no existe', async () => {
+      const mockMedico = { idMedico: 10, activo: true };
+      medicosModel.findByUserId.mockResolvedValue(mockMedico);
+      turnosModel.findById.mockResolvedValue(null);
+
+      await expect(turnosService.marcarComoAtendido(5, 1)).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+        message: 'El turno solicitado no existe',
+      });
     });
   });
 });

--- a/tp-final-integrador/tests/modules/turnos.test.js
+++ b/tp-final-integrador/tests/modules/turnos.test.js
@@ -121,7 +121,72 @@ describe('Turnos - Integration Tests', () => {
       expect(response.body.data.valorTotal).toBe(4500.0); // 5000 - 10%
     });
 
-    it('Scenario 3: Access denied for non-admin user (403)', async () => {
+    it('Scenario 3: Access allowed for patient user (201)', async () => {
+      const payload = {
+        idMedico: 1,
+        // idPaciente and idObraSocial should be resolved from profile, but let's send them to verify they are ignored/overridden
+        idPaciente: 999,
+        idObraSocial: 999,
+        fecha: '2026-07-20',
+        hora: '10:30',
+      };
+
+      const response = await request(app)
+        .post('/api/v1/turnos')
+        .set('Authorization', `Bearer ${patientToken}`)
+        .send(payload);
+
+      expect(response.status).toBe(201);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.idPaciente).toBe(1); // From profile
+      expect(response.body.data.idObraSocial).toBe(1); // From profile
+    });
+
+    it('Scenario: Successful registration as PACIENTE with minimal payload (201)', async () => {
+      const payload = {
+        idMedico: 1,
+        fecha: '2026-07-21',
+        hora: '11:00',
+      };
+
+      const response = await request(app)
+        .post('/api/v1/turnos')
+        .set('Authorization', `Bearer ${patientToken}`)
+        .send(payload);
+
+      expect(response.status).toBe(201);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.idPaciente).toBe(1);
+      expect(response.body.data.idObraSocial).toBe(1);
+    });
+
+    it('Scenario: Error 404 when PACIENTE has no record in pacientes table', async () => {
+      // Create a new user with role PACIENTE but no record in pacientes table
+      await pool.execute(
+        'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        [50, '50505050', 'NoProfile', 'User', 'noprofile@test.com', 'hash', '', ROLES.PACIENTE, 1],
+      );
+      const noProfileToken = jwt.sign(
+        { id: 50, rol: ROLES.PACIENTE, documento: '50505050' },
+        JWT_SECRET,
+      );
+
+      const payload = {
+        idMedico: 1,
+        fecha: '2026-07-15',
+        hora: '14:30',
+      };
+
+      const response = await request(app)
+        .post('/api/v1/turnos')
+        .set('Authorization', `Bearer ${noProfileToken}`)
+        .send(payload);
+
+      expect(response.status).toBe(404);
+      expect(response.body.error.message).toBe('Perfil de paciente no encontrado');
+    });
+
+    it('Scenario: Access denied for unauthorized role (Medico) (403)', async () => {
       const payload = {
         idMedico: 1,
         idPaciente: 1,
@@ -132,7 +197,7 @@ describe('Turnos - Integration Tests', () => {
 
       const response = await request(app)
         .post('/api/v1/turnos')
-        .set('Authorization', `Bearer ${patientToken}`)
+        .set('Authorization', `Bearer ${medicoToken}`)
         .send(payload);
 
       expect(response.status).toBe(403);
@@ -256,7 +321,7 @@ describe('Turnos - Integration Tests', () => {
       expect(response.body.error.code).toBe('VALIDATION_ERROR');
     });
 
-    it('Scenario 9: Patient double booking (422)', async () => {
+    it('Scenario 9: Patient double booking (409)', async () => {
       const payload = {
         idMedico: 1,
         idPaciente: 1,
@@ -273,20 +338,20 @@ describe('Turnos - Integration Tests', () => {
 
       expect(firstResponse.status).toBe(201);
 
-      // Segundo registro (solapamiento)
+      // Segundo registro (solapamiento de paciente)
       const secondResponse = await request(app)
         .post('/api/v1/turnos')
         .set('Authorization', `Bearer ${adminToken}`)
         .send(payload);
 
-      expect(secondResponse.status).toBe(422);
-      expect(secondResponse.body.error.code).toBe('VALIDATION_ERROR');
+      expect(secondResponse.status).toBe(409);
+      expect(secondResponse.body.error.code).toBe('DUPLICATE_ENTRY');
       expect(secondResponse.body.error.message).toBe(
-        'El médico ya tiene un turno reservado para la misma fecha y hora',
+        'El paciente ya tiene un turno reservado para la misma fecha y hora',
       );
     });
 
-    it('Scenario X: Physician time conflict (422)', async () => {
+    it('Scenario X: Physician time conflict (409)', async () => {
       // Necesitamos un segundo paciente para que no falle por solapamiento de paciente
       await pool.execute(
         'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
@@ -325,8 +390,8 @@ describe('Turnos - Integration Tests', () => {
         .set('Authorization', `Bearer ${adminToken}`)
         .send(payload2);
 
-      expect(secondResponse.status).toBe(422);
-      expect(secondResponse.body.error.code).toBe('VALIDATION_ERROR');
+      expect(secondResponse.status).toBe(409);
+      expect(secondResponse.body.error.code).toBe('DUPLICATE_ENTRY');
       expect(secondResponse.body.error.message).toBe(
         'El médico ya tiene un turno reservado para la misma fecha y hora',
       );

--- a/tp-final-integrador/tests/modules/turnos.test.js
+++ b/tp-final-integrador/tests/modules/turnos.test.js
@@ -9,6 +9,8 @@ import { ROLES } from '../../src/constants/roles.constants.js';
 describe('Turnos - Integration Tests', () => {
   let adminToken;
   let patientToken;
+  let medicoToken;
+  let otherMedicoToken;
   const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 
   beforeEach(async () => {
@@ -62,6 +64,18 @@ describe('Turnos - Integration Tests', () => {
     // Generar tokens
     adminToken = jwt.sign({ id: 8, rol: ROLES.ADMIN, documento: '51000111' }, JWT_SECRET);
     patientToken = jwt.sign({ id: 3, rol: ROLES.PACIENTE, documento: '33333333' }, JWT_SECRET);
+    medicoToken = jwt.sign({ id: 2, rol: ROLES.MEDICO, documento: '22222222' }, JWT_SECRET);
+
+    // Otro médico para probar pertenencia
+    await pool.execute(
+      'INSERT INTO usuarios (id_usuario, documento, apellido, nombres, email, contrasenia, foto_path, rol, activo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      [10, '10101010', 'Other', 'Medico', 'other@test.com', 'hash', '', ROLES.MEDICO, 1],
+    );
+    await pool.execute(
+      'INSERT INTO medicos (id_medico, id_usuario, id_especialidad, matricula, valor_consulta) VALUES (?, ?, ?, ?, ?)',
+      [2, 10, 1, 3000, 6000.0],
+    );
+    otherMedicoToken = jwt.sign({ id: 10, rol: ROLES.MEDICO, documento: '10101010' }, JWT_SECRET);
   });
 
   afterAll(async () => {
@@ -356,6 +370,78 @@ describe('Turnos - Integration Tests', () => {
 
       expect(response.status).toBe(422);
       expect(response.body.error.code).toBe('VALIDATION_ERROR');
+    });
+  });
+
+  describe('PATCH /api/v1/turnos/:id/atendido', () => {
+    let turnoId;
+
+    beforeEach(async () => {
+      // Crear un turno para las pruebas
+      const [result] = await pool.execute(
+        'INSERT INTO turnos_reservas (id_medico, id_paciente, id_obra_social, fecha_hora, valor_total, atendido, activo) VALUES (?, ?, ?, ?, ?, ?, ?)',
+        [1, 1, 1, '2026-07-15 14:30:00', 4500.0, 0, 1],
+      );
+      turnoId = result.insertId;
+    });
+
+    it('Scenario 1: Doctor marks their own appointment as attended (200)', async () => {
+      const response = await request(app)
+        .patch(`/api/v1/turnos/${turnoId}/atendido`)
+        .set('Authorization', `Bearer ${medicoToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.atendido).toBe(1);
+    });
+
+    it('Scenario 2: Unauthorized role (Patient) (403)', async () => {
+      const response = await request(app)
+        .patch(`/api/v1/turnos/${turnoId}/atendido`)
+        .set('Authorization', `Bearer ${patientToken}`);
+
+      expect(response.status).toBe(403);
+    });
+
+    it('Scenario 3: Ownership failure (403)', async () => {
+      const response = await request(app)
+        .patch(`/api/v1/turnos/${turnoId}/atendido`)
+        .set('Authorization', `Bearer ${otherMedicoToken}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body.error.message).toBe(
+        'No tiene permisos para marcar este turno como atendido',
+      );
+    });
+
+    it('Scenario 4: Conflict - Already attended (409)', async () => {
+      // Marcar como atendido primero
+      await pool.execute('UPDATE turnos_reservas SET atendido = 1 WHERE id_turno_reserva = ?', [
+        turnoId,
+      ]);
+
+      const response = await request(app)
+        .patch(`/api/v1/turnos/${turnoId}/atendido`)
+        .set('Authorization', `Bearer ${medicoToken}`);
+
+      expect(response.status).toBe(409);
+      expect(response.body.error.message).toBe('El turno ya ha sido marcado como atendido');
+    });
+
+    it('Scenario 5: Not found (404)', async () => {
+      const response = await request(app)
+        .patch('/api/v1/turnos/9999/atendido')
+        .set('Authorization', `Bearer ${medicoToken}`);
+
+      expect(response.status).toBe(404);
+    });
+
+    it('Scenario 6: Invalid ID format (422)', async () => {
+      const response = await request(app)
+        .patch('/api/v1/turnos/abc/atendido')
+        .set('Authorization', `Bearer ${medicoToken}`);
+
+      expect(response.status).toBe(422);
     });
   });
 });

--- a/tp-final-integrador/tests/setup/db.js
+++ b/tp-final-integrador/tests/setup/db.js
@@ -13,13 +13,13 @@ export const clearDatabase = async () => {
   try {
     await pool.execute('SET FOREIGN_KEY_CHECKS = 0');
 
-    // Lista de tablas a limpiar (en orden de dependencia si fuera necesario, aunque con checks en 0 no importa tanto)
+    // Lista de tablas a limpiar
     const tables = [
+      'especialidades',
       'turnos_reservas',
       'medicos_obras_sociales',
       'pacientes',
       'medicos',
-      'especialidades',
       'obras_sociales',
       'usuarios',
     ];


### PR DESCRIPTION
Closes #90

### Resumen
* Permite a los usuarios con rol de `PACIENTE` registrar sus propios turnos mediante `POST /api/v1/turnos`.
* Resuelve el `idPaciente` y el `idObraSocial` de manera segura desde la identidad del token (`req.user.id`), protegiendo la API contra vulnerabilidades.
* Corrige el orden de validación en caso de superposición horaria (validando el paciente antes que el médico para ofrecer mensajes de error más precisos al paciente) y actualiza el código de estado a `409 Conflict` (`DUPLICATE_ENTRY`).

### Cambios realizados
| Archivo | Cambio |
|------|--------|
| `src/routes/turnos.routes.js` | Habilitar acceso de pacientes al método POST. |
| `src/controllers/turnos.controller.js` | Enviar el ID de usuario y rol autenticados al servicio de turnos. |
| `src/validators/turnos.validator.js` | Hacer condicionales las validaciones de `idPaciente` e `idObraSocial` en el body (solo obligatorias para administradores). |
| `src/services/turnos.service.js` | Resolver perfil del paciente por su ID de usuario y reescribir los identificadores de la reserva. Validar superposición de paciente antes que del médico con código de estado HTTP 409. |
| `tests/modules/turnos.service.test.js` | Adaptar y agregar pruebas unitarias para el flujo del paciente y el nuevo código 409. |
| `tests/modules/turnos.test.js` | Agregar pruebas de integración para el registro exitoso del paciente, desprotección de perfil, control de roles no autorizados (médicos) con 403 y conflicto 409. |
| `bruno-collection/turnos/registrar-como-paciente.bru` | Nueva request de prueba para registrar turnos como paciente. |
| `docs/ENDPOINTS.md` | Documentar el acceso y lógica del endpoint modificado. |
| `init/schema.sql`, `prog3_turnos.sql`, `prog3_turnos_modif.sql` | Sembrar un nuevo paciente de pruebas (`Carlos Perez`, id 4) para facilitar los ensayos. |

### Plan de Pruebas
- [x] Ejecutado localmente y comprobado que los 192 tests de integración y unitarios pasen sin fallos.
- [x] Validado el correcto funcionamiento del control de accesos con múltiples roles.