### PR TITLE
chore: reubicar y configurar workflow de linting en la raíz

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,6 +8,9 @@ jobs:
   quality-check:
     name: Lint & Format Check
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tp-final-integrador
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -15,8 +18,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: 'tp-final-integrador/.nvmrc'
           cache: 'npm'
+          cache-dependency-path: 'tp-final-integrador/package-lock.json'
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Se movió el archivo de configuración de GitHub Actions a la raíz del repositorio y se ajustó para que ejecute el linting en la carpeta 'tp-final-integrador'.