### PR TITLE
refactor(db): simplificar consultas usando vistas v_medicos y v_pacientes

### DIFF
--- a/tp-final-integrador/docs/migracion.sql
+++ b/tp-final-integrador/docs/migracion.sql
@@ -33,32 +33,37 @@ DROP VIEW IF EXISTS `v_medicos`;
 CREATE VIEW `v_medicos` AS
 SELECT
     m.id_medico,
+    m.id_usuario,
+    m.id_especialidad,
     u.apellido,
     u.nombres,
+    u.documento,
+    u.email,
     e.nombre AS especialidad,
     m.matricula,
     m.valor_consulta,
-    u.foto_path
+    u.foto_path,
+    u.activo
 FROM medicos m
 JOIN usuarios u ON m.id_usuario = u.id_usuario
-JOIN especialidades e ON m.id_especialidad = e.id_especialidad
-WHERE u.activo = 1 AND e.activo = 1;
+JOIN especialidades e ON m.id_especialidad = e.id_especialidad;
 
 DROP VIEW IF EXISTS `v_pacientes`;
 CREATE VIEW `v_pacientes` AS
 SELECT
     p.id_paciente,
     p.id_usuario,
+    p.id_obra_social,
+    os.nombre AS nombre_obra_social,
     u.apellido,
     u.nombres,
+    u.documento,
     u.email,
-    os.id_obra_social,
-    os.nombre AS nombre_obra_social,
-    u.foto_path
+    u.foto_path,
+    u.activo
 FROM pacientes p
 JOIN usuarios u ON p.id_usuario = u.id_usuario
-JOIN obras_sociales os ON p.id_obra_social = os.id_obra_social
-WHERE u.activo = 1 AND os.activo = 1;
+LEFT JOIN obras_sociales os ON p.id_obra_social = os.id_obra_social;
 
 -- 5. Crear Procedimientos Almacenados
 DELIMITER $$

--- a/tp-final-integrador/init/schema.sql
+++ b/tp-final-integrador/init/schema.sql
@@ -272,12 +272,17 @@ INSERT INTO `usuarios` (`id_usuario`, `documento`, `apellido`, `nombres`, `email
 --
 CREATE TABLE `v_medicos` (
 `id_medico` int(10) unsigned
+,`id_usuario` int(10) unsigned
+,`id_especialidad` int(10) unsigned
 ,`apellido` varchar(100)
 ,`nombres` varchar(100)
+,`documento` varchar(20)
+,`email` varchar(255)
 ,`especialidad` varchar(120)
 ,`matricula` int(10) unsigned
 ,`valor_consulta` decimal(10,2)
 ,`foto_path` varchar(255)
+,`activo` tinyint(3) unsigned
 );
 
 -- --------------------------------------------------------
@@ -288,12 +293,14 @@ CREATE TABLE `v_medicos` (
 CREATE TABLE `v_pacientes` (
 `id_paciente` int(10) unsigned
 ,`id_usuario` int(10) unsigned
-,`apellido` varchar(100)
-,`nombres` varchar(100)
-,`email` varchar(255)
 ,`id_obra_social` int(10) unsigned
 ,`nombre_obra_social` varchar(255)
+,`apellido` varchar(100)
+,`nombres` varchar(100)
+,`documento` varchar(20)
+,`email` varchar(255)
 ,`foto_path` varchar(255)
+,`activo` tinyint(3) unsigned
 );
 
 -- --------------------------------------------------------
@@ -306,16 +313,20 @@ DROP TABLE IF EXISTS `v_medicos`;
 CREATE VIEW `v_medicos` AS
 SELECT
     m.id_medico,
+    m.id_usuario,
+    m.id_especialidad,
     u.apellido,
     u.nombres,
+    u.documento,
+    u.email,
     e.nombre AS especialidad,
     m.matricula,
     m.valor_consulta,
-    u.foto_path
+    u.foto_path,
+    u.activo
 FROM medicos m
 JOIN usuarios u ON m.id_usuario = u.id_usuario
-JOIN especialidades e ON m.id_especialidad = e.id_especialidad
-WHERE u.activo = 1 AND e.activo = 1;
+JOIN especialidades e ON m.id_especialidad = e.id_especialidad;
 
 -- --------------------------------------------------------
 
@@ -328,16 +339,17 @@ CREATE VIEW `v_pacientes` AS
 SELECT
     p.id_paciente,
     p.id_usuario,
+    p.id_obra_social,
+    os.nombre AS nombre_obra_social,
     u.apellido,
     u.nombres,
+    u.documento,
     u.email,
-    os.id_obra_social,
-    os.nombre AS nombre_obra_social,
-    u.foto_path
+    u.foto_path,
+    u.activo
 FROM pacientes p
 JOIN usuarios u ON p.id_usuario = u.id_usuario
-JOIN obras_sociales os ON p.id_obra_social = os.id_obra_social
-WHERE u.activo = 1 AND os.activo = 1;
+LEFT JOIN obras_sociales os ON p.id_obra_social = os.id_obra_social;
 
 --
 -- Índices para tablas volcadas

--- a/tp-final-integrador/src/database/medicos.js
+++ b/tp-final-integrador/src/database/medicos.js
@@ -9,10 +9,7 @@ import { DB_STATUS } from '../constants/common.constants.js';
  */
 export const findById = async (id) => {
   const query = `
-    SELECT m.id_medico, m.id_usuario, m.id_especialidad, m.matricula, m.valor_consulta, u.activo, u.apellido, u.nombres
-    FROM medicos m
-    JOIN usuarios u ON m.id_usuario = u.id_usuario
-    WHERE m.id_medico = ?
+    SELECT * FROM v_medicos WHERE id_medico = ?
   `;
   const [rows] = await pool.execute(query, [id]);
 
@@ -27,10 +24,7 @@ export const findById = async (id) => {
  */
 export const findByUserId = async (idUsuario) => {
   const query = `
-    SELECT m.id_medico, m.id_usuario, m.id_especialidad, m.matricula, m.valor_consulta, u.activo
-    FROM medicos m
-    JOIN usuarios u ON m.id_usuario = u.id_usuario
-    WHERE m.id_usuario = ?
+    SELECT * FROM v_medicos WHERE id_usuario = ?
   `;
   const [rows] = await pool.execute(query, [idUsuario]);
 
@@ -119,18 +113,7 @@ export const assignObrasSociales = async (idMedico, idsObrasSociales) => {
  */
 export const findAll = async () => {
   const query = `
-    SELECT
-      m.id_medico,
-      m.id_usuario,
-      m.id_especialidad,
-      m.matricula,
-      m.valor_consulta,
-      u.nombres,
-      u.apellido,
-      u.activo
-    FROM medicos m
-    JOIN usuarios u ON m.id_usuario = u.id_usuario
-    WHERE u.activo = ?
+    SELECT * FROM v_medicos WHERE activo = ?
   `;
 
   const [rows] = await pool.execute(query, [DB_STATUS.ACTIVE]);
@@ -140,17 +123,7 @@ export const findAll = async () => {
 
 export const findByEspecialidad = async (idEspecialidad) => {
   const query = `
-    SELECT
-      m.id_medico,
-      m.id_especialidad,
-      m.matricula,
-      m.valor_consulta,
-      u.nombres,
-      u.apellido,
-      u.activo
-    FROM medicos m
-    JOIN usuarios u ON m.id_usuario = u.id_usuario
-    WHERE m.id_especialidad = ? AND u.activo = ?
+    SELECT * FROM v_medicos WHERE id_especialidad = ? AND activo = ?
   `;
 
   const [rows] = await pool.execute(query, [idEspecialidad, DB_STATUS.ACTIVE]);

--- a/tp-final-integrador/src/database/pacientes.js
+++ b/tp-final-integrador/src/database/pacientes.js
@@ -6,19 +6,7 @@ import * as pacientesMapper from './pacientes.mapper.js';
  * @returns {Promise<Object|null>}
  */
 export const findAll = async () => {
-  const query = `
-  SELECT
-  p.id_paciente,
-  p.id_usuario,
-  p.id_obra_social,
-  os.nombre AS nombre_obra_social,
-  u.apellido,
-  u.nombres,
-  u.documento,
-  u.activo
-  FROM pacientes p
-  JOIN usuarios u ON p.id_usuario = u.id_usuario
-  LEFT JOIN obras_sociales os ON p.id_obra_social = os.id_obra_social`;
+  const query = `SELECT * FROM v_pacientes`;
   const [rows] = await pool.execute(query);
 
   if (rows.length === 0) return null;
@@ -32,20 +20,7 @@ export const findAll = async () => {
  * @returns {Promise<Object|null>}
  */
 export const findById = async (id) => {
-  const query = `
-    SELECT
-    p.id_paciente,
-    p.id_usuario,
-    p.id_obra_social,
-    os.nombre AS nombre_obra_social,
-    u.apellido,
-    u.nombres,
-    u.documento,
-    u.activo
-    FROM pacientes p
-    JOIN usuarios u ON p.id_usuario = u.id_usuario
-    LEFT JOIN obras_sociales os ON p.id_obra_social = os.id_obra_social
-    WHERE p.id_paciente = ?`;
+  const query = `SELECT * FROM v_pacientes WHERE id_paciente = ?`;
   const [rows] = await pool.execute(query, [id]);
 
   if (rows.length === 0) return null;
@@ -58,21 +33,7 @@ export const findById = async (id) => {
  * @returns {Promise<Object|null>}
  */
 export const findByUserId = async (idUsuario) => {
-  const query = `
-    SELECT
-    p.id_paciente,
-    p.id_usuario,
-    p.id_obra_social,
-    os.nombre AS nombre_obra_social,
-    u.apellido,
-    u.nombres,
-    u.documento,
-    u.activo
-    FROM pacientes p
-    JOIN usuarios u ON p.id_usuario = u.id_usuario
-    LEFT JOIN obras_sociales os ON p.id_obra_social = os.id_obra_social
-    WHERE p.id_usuario = ?
-  `;
+  const query = `SELECT * FROM v_pacientes WHERE id_usuario = ?`;
   const [rows] = await pool.execute(query, [idUsuario]);
 
   if (rows.length === 0) return null;


### PR DESCRIPTION
## Descripción

Este pull request implementa una refactorización en el acceso a datos para los módulos de médicos y pacientes. En lugar de realizar acoplamientos y `JOIN`s manuales complejos en múltiples consultas de la aplicación, ahora se consumen las vistas de base de datos actualizadas `v_medicos` y `v_pacientes`.

### Cambios realizados

1. **Esquema de Base de Datos y Migraciones (`init/schema.sql` y `docs/migracion.sql`)**:
   - Se actualizaron las definiciones de `v_medicos` y `v_pacientes` para incluir campos clave adicionales (`id_usuario`, `id_especialidad`, `documento`, `email`, `activo`, `id_obra_social`, etc.).
   - Se removió la cláusula restrictiva `WHERE activo = 1` de las definiciones de las vistas. Esto traslada la responsabilidad de filtrado de registros activos a las consultas específicas de la aplicación, haciendo a las vistas más flexibles (útiles tanto para listados de activos como para consultas de administración).
   - Se modificó la relación de `obras_sociales` en `v_pacientes` a un `LEFT JOIN`. Esto corrige el comportamiento anterior donde los pacientes sin una obra social asociada eran omitidos incorrectamente en los resultados de la vista.

2. **Modelos de Base de Datos (`src/database/medicos.js` y `src/database/pacientes.js`)**:
   - Se simplificaron métodos como `findById`, `findByUserId`, `findAll` y `findByEspecialidad` reemplazando las consultas manuales multi-tabla por llamadas directas sobre `v_medicos` y `v_pacientes`.
   - Esto reduce drásticamente la duplicación de código SQL y facilita el mantenimiento futuro.

### Decisiones de Diseño

- **Flexibilidad de las Vistas**: Al remover los filtros de estado (`activo = 1`) de la definición de la vista, logramos que la misma estructura de datos sirva para todos los casos de uso sin tener que crear vistas duplicadas o consultas complejas separadas.
- **Inclusión de Pacientes sin Obra Social**: El cambio a `LEFT JOIN` previene bugs de pérdida de datos en pacientes particulares o sin cobertura.
